### PR TITLE
support concurrency across relays in the `RelayMux`

### DIFF
--- a/mev-boost-rs/src/relay_mux.rs
+++ b/mev-boost-rs/src/relay_mux.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use ethereum_consensus::clock;
 use ethereum_consensus::primitives::Hash32;
 use ethereum_consensus::state_transition::{Context, Error as ConsensusError};
-use futures::StreamExt;
+use futures::{stream, StreamExt};
 use mev_build_rs::{
     verify_signed_builder_message, ApiClient as Relay, BidRequest, Builder, Error as BuilderError,
     ExecutionPayload, SignedBlindedBeaconBlock, SignedBuilderBid, SignedValidatorRegistration,
@@ -55,6 +55,8 @@ impl std::ops::Deref for RelayMux {
 }
 
 pub struct RelayMuxInner {
+    // TODO: this can likely be faster by just having a list of URLs
+    // and one shared API client
     relays: Vec<Relay>,
     context: Arc<Context>,
     state: Mutex<State>,
@@ -98,11 +100,12 @@ impl Builder for RelayMux {
         &self,
         registrations: &mut [SignedValidatorRegistration],
     ) -> Result<(), BuilderError> {
-        // TODO (and below) do this concurrently?
-        let mut responses = vec![];
-        for relay in &self.relays {
-            responses.push(relay.register_validator(registrations).await)
-        }
+        let registrations = &registrations;
+        let responses = stream::iter(self.relays.iter().cloned())
+            .map(|relay| async move { relay.register_validator(registrations).await })
+            .buffer_unordered(self.relays.len())
+            .collect::<Vec<_>>()
+            .await;
 
         let failures = responses.iter().filter(|r| r.is_err());
 
@@ -115,12 +118,13 @@ impl Builder for RelayMux {
 
     async fn fetch_best_bid(
         &self,
-        bid_request: &mut BidRequest,
+        bid_request: &BidRequest,
     ) -> Result<SignedBuilderBid, BuilderError> {
-        let mut bids = vec![];
-        for relay in &self.relays {
-            bids.push(relay.fetch_best_bid(bid_request).await)
-        }
+        let bids = stream::iter(self.relays.iter().cloned())
+            .map(|relay| async move { relay.fetch_best_bid(bid_request).await })
+            .buffer_unordered(self.relays.len())
+            .collect::<Vec<_>>()
+            .await;
 
         let mut best_bid_value = U256::default();
         let mut best_bids = vec![];
@@ -182,11 +186,13 @@ impl Builder for RelayMux {
             }
         };
 
-        let mut responses = vec![];
-        for i in relay_indices {
-            let relay = &self.relays[i];
-            responses.push(relay.open_bid(signed_block).await);
-        }
+        let signed_block = &signed_block;
+        let relays = relay_indices.into_iter().map(|i| self.relays[i].clone());
+        let responses = stream::iter(relays)
+            .map(|relay| async move { relay.open_bid(signed_block).await })
+            .buffer_unordered(self.relays.len())
+            .collect::<Vec<_>>()
+            .await;
 
         let mut opened_payload = None;
         let expected_block_hash = &signed_block

--- a/mev-boost-rs/tests/integration.rs
+++ b/mev-boost-rs/tests/integration.rs
@@ -9,7 +9,7 @@ use ethereum_consensus::primitives::{DomainType, ExecutionAddress, Hash32, Slot}
 use ethereum_consensus::signing::sign_with_domain;
 use ethereum_consensus::state_transition::Context;
 use mev_boost_rs::{Config, Service};
-use mev_build_rs::{sign_builder_message, ApiClient as RelayClient, BidRequest, Builder};
+use mev_build_rs::{sign_builder_message, ApiClient as RelayClient, BidRequest};
 use mev_relay_rs::{Config as RelayConfig, Service as Relay};
 use rand;
 use rand::seq::SliceRandom;
@@ -93,7 +93,7 @@ async fn test_end_to_end() {
     beacon_node.check_status().await.unwrap();
 
     let context = Context::for_mainnet();
-    let mut registrations = proposers
+    let registrations = proposers
         .iter()
         .map(|proposer| {
             let timestamp = get_time();
@@ -112,7 +112,7 @@ async fn test_end_to_end() {
         })
         .collect::<Vec<_>>();
     beacon_node
-        .register_validator(&mut registrations)
+        .register_validator(&registrations)
         .await
         .unwrap();
 

--- a/mev-build-rs/src/builder.rs
+++ b/mev-build-rs/src/builder.rs
@@ -12,8 +12,7 @@ pub trait Builder {
         registrations: &mut [SignedValidatorRegistration],
     ) -> Result<(), Error>;
 
-    async fn fetch_best_bid(&self, bid_request: &mut BidRequest)
-        -> Result<SignedBuilderBid, Error>;
+    async fn fetch_best_bid(&self, bid_request: &BidRequest) -> Result<SignedBuilderBid, Error>;
 
     async fn open_bid(
         &self,

--- a/mev-build-rs/src/builder_api_server.rs
+++ b/mev-build-rs/src/builder_api_server.rs
@@ -43,12 +43,12 @@ async fn handle_validator_registration<B: Builder>(
 }
 
 async fn handle_fetch_bid<B: Builder>(
-    Path(mut bid_request): Path<BidRequest>,
+    Path(bid_request): Path<BidRequest>,
     Extension(builder): Extension<B>,
 ) -> Result<Json<VersionedValue<SignedBuilderBid>>, Error> {
     tracing::debug!("fetching best bid for block for request {bid_request:?}");
 
-    let signed_bid = builder.fetch_best_bid(&mut bid_request).await?;
+    let signed_bid = builder.fetch_best_bid(&bid_request).await?;
 
     Ok(Json(VersionedValue {
         version: ConsensusVersion::Bellatrix,

--- a/mev-build-rs/src/client.rs
+++ b/mev-build-rs/src/client.rs
@@ -1,12 +1,15 @@
-use crate::builder::Builder;
 use crate::error::Error;
 use crate::types::{
     BidRequest, ExecutionPayload, SignedBlindedBeaconBlock, SignedBuilderBid,
     SignedValidatorRegistration,
 };
-use async_trait::async_trait;
 use beacon_api_client::{api_error_or_ok, Client as BeaconApiClient, VersionedValue};
 
+/// A `Client` for a service implementing the Builder APIs.
+/// Note that `Client` does not implement the `Builder` trait so that
+/// it can provide more flexibility to callers with respect to the types
+/// it accepts.
+#[derive(Clone)]
 pub struct Client {
     api: BeaconApiClient,
 }
@@ -20,13 +23,10 @@ impl Client {
         let response = self.api.http_get("/eth/v1/builder/status").await?;
         api_error_or_ok(response).await
     }
-}
 
-#[async_trait]
-impl Builder for Client {
-    async fn register_validator(
+    pub async fn register_validator(
         &self,
-        registrations: &mut [SignedValidatorRegistration],
+        registrations: &[SignedValidatorRegistration],
     ) -> Result<(), Error> {
         let response = self
             .api
@@ -36,9 +36,9 @@ impl Builder for Client {
         Ok(result)
     }
 
-    async fn fetch_best_bid(
+    pub async fn fetch_best_bid(
         &self,
-        bid_request: &mut BidRequest,
+        bid_request: &BidRequest,
     ) -> Result<SignedBuilderBid, Error> {
         let target = format!(
             "/eth/v1/builder/header/{}/{}/{}",
@@ -48,9 +48,9 @@ impl Builder for Client {
         Ok(response.data)
     }
 
-    async fn open_bid(
+    pub async fn open_bid(
         &self,
-        signed_block: &mut SignedBlindedBeaconBlock,
+        signed_block: &SignedBlindedBeaconBlock,
     ) -> Result<ExecutionPayload, Error> {
         let response: VersionedValue<ExecutionPayload> = self
             .api

--- a/mev-relay-rs/src/relay.rs
+++ b/mev-relay-rs/src/relay.rs
@@ -169,7 +169,7 @@ impl Builder for Relay {
 
     async fn fetch_best_bid(
         &self,
-        bid_request: &mut BidRequest,
+        bid_request: &BidRequest,
     ) -> Result<SignedBuilderBid, BuilderError> {
         validate_bid_request(bid_request).await?;
 


### PR DESCRIPTION
the relay mux currently communicates with connected relays in a serial manner

this PR allows the IO to happen concurrently

NOTE: due to dependency requirements on caching the hash tree root in https://github.com/ralexstokes/ssz-rs needing `mut` capabilities, either the `Builder` trait had to expand to fit a variety of abilities or the relay `Client` had to fall out of the `Builder` implementer set. This PR chooses the latter and the mutability story for hash tree root caching should be considered as it has far reaching effects across any consumer of that library