### PR TITLE
Release actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,125 @@
+name:   Release Suite
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  extract-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract version
+        run: echo "::set-output name=VERSION::$(echo ${GITHUB_REF#refs/tags/})"
+        id: extract_version
+    outputs:
+      VERSION: ${{ steps.extract_version.outputs.VERSION }}
+  build:
+    name:   Build Release
+    strategy:
+      matrix:
+        arch: [aarch64-unknown-linux-gnu,
+               x86_64-unknown-linux-gnu,
+               x86_64-apple-darwin]
+        include:
+          -   arch: aarch64-unknown-linux-gnu
+              platform: ubuntu-latest
+          -   arch: x86_64-unknown-linux-gnu
+              platform: ubuntu-latest
+          -   arch: x86_64-apple-darwin
+              platform: macos-latest
+
+    runs-on:    ${{ matrix.platform }}
+    needs: extract-version
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Build toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile:  minimal
+          override: true
+
+      # ==============================
+      #       Build
+      # ==============================
+
+      - name: Build mev-rs
+        run:  |
+          cargo install --path mev-rs --locked
+          mkdir artifacts
+          mv ~/.cargo/bin/mev ./artifacts
+          cd artifacts
+          tar -czf mev-rs-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz mev
+          mv *tar.gz* ..
+
+      # =======================================================================
+      # Upload artifacts
+      # This is required to share artifacts between different jobs
+      # =======================================================================
+
+      - name:  Upload artifact
+        uses:  actions/upload-artifact@v2
+        with:
+          name: mev-rs-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz
+          path: mev-rs-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz
+
+  draft-release:
+    name:   Draft Release
+    needs:  [build, extract-version]
+    runs-on: ubuntu-latest
+    env:
+      VERSION:  ${{ needs.extract-version.outputs.VERSION }}
+    steps:
+      # This is necessary for generating the changelog. It has to come before "Download Artifacts" or else it deletes the artifacts.
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      # ==============================
+      #       Download artifacts
+      # ==============================
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+
+      # ==============================
+      #       Create release draft
+      # ==============================
+
+      - name: Generate Full Changelog
+        id: changelog
+        run: echo "::set-output name=CHANGELOG::$(git log --pretty=format:"- %s" $(git describe --tags --abbrev=0 ${{ env.VERSION }}^)..${{ env.VERSION }})"
+
+      - name: Create Release Draft
+        env:
+          GITHUB_USER: realbigsean
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        # The formatting here is adapted from OpenEthereum: https://github.com/openethereum/openethereum/blob/main/.github/workflows/build.yml
+        run: |
+          body=$(cat <<- "ENDBODY"
+          ${{ env.VERSION }}
+         
+          ## Changelog
+          
+          ${{ steps.changelog.outputs.CHANGELOG }}
+          
+          ## Binaries
+          
+          | System | Architecture | Binary |
+          |:---:|:---:|:---:|
+          | <img src="https://simpleicons.org/icons/apple.svg" style="width: 32px;"/> | x86_64 | [mev-rs-${{ env.VERSION }}-x86_64-apple-darwin.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/mev-rs-${{ env.VERSION }}-x86_64-apple-darwin.tar.gz) | 
+          | <img src="https://simpleicons.org/icons/linux.svg" style="width: 32px;"/> | x86_64 | [mev-rs-${{ env.VERSION }}-x86_64-unknown-linux-gnu.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/mev-rs-${{ env.VERSION }}-x86_64-unknown-linux-gnu.tar.gz) | 
+          | <img src="https://simpleicons.org/icons/raspberrypi.svg" style="width: 32px;"/> | aarch64 | [mev-rs-${{ env.VERSION }}-aarch64-unknown-linux-gnu.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/mev-rs-${{ env.VERSION }}-aarch64-unknown-linux-gnu.tar.gz) | 
+
+          ENDBODY
+          )
+          assets=()
+          for asset in ./mev-rs-*.tar.gz*; do
+              assets+=("-a" "$asset/$asset")
+          done
+          tag_name="${{ env.VERSION }}"
+          echo "$body" | hub release create --draft "${assets[@]}" -F "-" "$tag_name"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,12 +18,9 @@ jobs:
     name:   Build Release
     strategy:
       matrix:
-        arch: [aarch64-unknown-linux-gnu,
-               x86_64-unknown-linux-gnu,
+        arch: [x86_64-unknown-linux-gnu,
                x86_64-apple-darwin]
         include:
-          -   arch: aarch64-unknown-linux-gnu
-              platform: ubuntu-latest
           -   arch: x86_64-unknown-linux-gnu
               platform: ubuntu-latest
           -   arch: x86_64-apple-darwin
@@ -95,7 +92,7 @@ jobs:
 
       - name: Create Release Draft
         env:
-          GITHUB_USER: realbigsean
+          GITHUB_USER: ralexstokes
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
         # The formatting here is adapted from OpenEthereum: https://github.com/openethereum/openethereum/blob/main/.github/workflows/build.yml
@@ -113,7 +110,6 @@ jobs:
           |:---:|:---:|:---:|
           | <img src="https://simpleicons.org/icons/apple.svg" style="width: 32px;"/> | x86_64 | [mev-rs-${{ env.VERSION }}-x86_64-apple-darwin.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/mev-rs-${{ env.VERSION }}-x86_64-apple-darwin.tar.gz) | 
           | <img src="https://simpleicons.org/icons/linux.svg" style="width: 32px;"/> | x86_64 | [mev-rs-${{ env.VERSION }}-x86_64-unknown-linux-gnu.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/mev-rs-${{ env.VERSION }}-x86_64-unknown-linux-gnu.tar.gz) | 
-          | <img src="https://simpleicons.org/icons/raspberrypi.svg" style="width: 32px;"/> | aarch64 | [mev-rs-${{ env.VERSION }}-aarch64-unknown-linux-gnu.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/mev-rs-${{ env.VERSION }}-aarch64-unknown-linux-gnu.tar.gz) | 
 
           ENDBODY
           )

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,8 +11,12 @@ env:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        platform: [ ubuntu-latest,
+                    macos-latest ]
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform }}
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This is adapted from the lighthouse release github action. I removed some features, maybe we can add them later (windows and aarch64 builds, gpg signing over the binary).

This creates a draft release. I published a draft I tested with here: https://github.com/realbigsean/mev-rs/releases/tag/v0.1.1

I removed the aarch64 binary that's produced in that example for this PR.

I also added a macos run to the `rust-ci.yml` because I figured we'd want that to make mac binaries. 