### PR TITLE
Pin beacon-api-client

### DIFF
--- a/mev-boost-rs/Cargo.toml
+++ b/mev-boost-rs/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0.30"
 
 ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus" }
-beacon-api-client = { git = "https://github.com/ralexstokes/beacon-api-client" }
+beacon-api-client = { git = "https://github.com/ralexstokes/beacon-api-client", rev = "bbfccc7f21d71465b38bc7910e3ea867d7facf4f"}
 
 mev-build-rs = { path = "../mev-build-rs" }
 mev-relay-rs = { path = "../mev-relay-rs" }

--- a/mev-build-rs/Cargo.toml
+++ b/mev-build-rs/Cargo.toml
@@ -21,4 +21,4 @@ thiserror = "1.0.30"
 
 ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus" }
 ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs" }
-beacon-api-client = { git = "https://github.com/ralexstokes/beacon-api-client", optional = true }
+beacon-api-client = { git = "https://github.com/ralexstokes/beacon-api-client", rev = "bbfccc7f21d71465b38bc7910e3ea867d7facf4f",  optional = true }


### PR DESCRIPTION
This [commit](https://github.com/ralexstokes/beacon-api-client/commit/20cea63411fc22d5c39fe40d84ee241c1d64e3cd) has broken `mev-rs`. 

This repo is a dep of lighthouse and I like to regularly run `cargo update` to update all our deps where reasonable. `mev-rs` no longer compiles because the deps are not pinned to a version or commit. 

It might be nicer to manage in the future to pin your own deps to specific versions, so you can update them independently without worrying about integration amongst all the repos.