### PR TITLE
Update beacon-api-client dependency, re-export dependencies needed in the public api

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,8 @@ jobs:
       run: rustup update stable
     - name: Rust Cache
       uses: Swatinem/rust-cache@v1.3.0
+    - name: Install protobuf compiler for the libp2p-core dependency
+      uses: arduino/setup-protoc@v1
     - name: Format
       run: cargo fmt -- --check
     - name: Run clippy

--- a/mev-boost-rs/Cargo.toml
+++ b/mev-boost-rs/Cargo.toml
@@ -17,8 +17,7 @@ url = { version = "2.2.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0.30"
 
-ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "e1188b1" }
-beacon-api-client = { git = "https://github.com/ralexstokes/beacon-api-client", rev = "de34eeb" }
+beacon-api-client = { git = "https://github.com/sigp/beacon-api-client", rev = "c1ce3f68cb1059f7fad96b89c9bd3b2c6c402513" }
 
 mev-build-rs = { path = "../mev-build-rs" }
 mev-relay-rs = { path = "../mev-relay-rs" }

--- a/mev-boost-rs/Cargo.toml
+++ b/mev-boost-rs/Cargo.toml
@@ -17,7 +17,7 @@ url = { version = "2.2.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0.30"
 
-beacon-api-client = { git = "https://github.com/sigp/beacon-api-client", rev = "c1ce3f68cb1059f7fad96b89c9bd3b2c6c402513" }
+beacon-api-client = { git = "https://github.com/sigp/beacon-api-client", rev = "68a4eaf4e4f0bddd6d799810f3ed78dc702091c8" }
 
 mev-build-rs = { path = "../mev-build-rs" }
 mev-relay-rs = { path = "../mev-relay-rs" }

--- a/mev-boost-rs/src/relay_mux.rs
+++ b/mev-boost-rs/src/relay_mux.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use beacon_api_client::ethereum_consensus;
 use ethereum_consensus::clock::{Clock, SystemTimeProvider};
 use ethereum_consensus::primitives::{BlsPublicKey, Hash32, Slot, U256};
 use ethereum_consensus::state_transition::{Context, Error as ConsensusError};

--- a/mev-boost-rs/src/service.rs
+++ b/mev-boost-rs/src/service.rs
@@ -1,6 +1,6 @@
 use crate::relay_mux::RelayMux;
+use beacon_api_client::ethereum_consensus::state_transition::Context;
 use beacon_api_client::Client;
-use ethereum_consensus::state_transition::Context;
 use futures::future::join_all;
 use mev_build_rs::{BlindedBlockProviderClient as Relay, BlindedBlockProviderServer, Network};
 use serde::Deserialize;

--- a/mev-boost-rs/tests/integration.rs
+++ b/mev-boost-rs/tests/integration.rs
@@ -1,3 +1,4 @@
+use beacon_api_client::ethereum_consensus;
 use beacon_api_client::{Client as ApiClient, ValidatorStatus, ValidatorSummary, Value};
 use ethereum_consensus::bellatrix::mainnet::{
     BlindedBeaconBlock, BlindedBeaconBlockBody, SignedBlindedBeaconBlock,

--- a/mev-build-rs/Cargo.toml
+++ b/mev-build-rs/Cargo.toml
@@ -20,4 +20,4 @@ serde_json = { version = "1.0.81", optional = true }
 thiserror = "1.0.30"
 
 ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "cb08f1" }
-beacon-api-client = { git = "https://github.com/sigp/beacon-api-client", rev = "c1ce3f68cb1059f7fad96b89c9bd3b2c6c402513", optional = true }
+beacon-api-client = { git = "https://github.com/sigp/beacon-api-client", rev = "68a4eaf4e4f0bddd6d799810f3ed78dc702091c8", optional = true }

--- a/mev-build-rs/Cargo.toml
+++ b/mev-build-rs/Cargo.toml
@@ -19,6 +19,5 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0.81", optional = true }
 thiserror = "1.0.30"
 
-ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "e1188b1" }
 ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "cb08f1" }
-beacon-api-client = { git = "https://github.com/ralexstokes/beacon-api-client", rev = "de34eeb", optional = true }
+beacon-api-client = { git = "https://github.com/sigp/beacon-api-client", rev = "c1ce3f68cb1059f7fad96b89c9bd3b2c6c402513", optional = true }

--- a/mev-build-rs/src/blinded_block_provider/mod.rs
+++ b/mev-build-rs/src/blinded_block_provider/mod.rs
@@ -10,8 +10,8 @@ use crate::types::{
     SignedValidatorRegistration,
 };
 use async_trait::async_trait;
+use beacon_api_client::ethereum_consensus::state_transition::Error as ConsensusError;
 use beacon_api_client::ApiError;
-use ethereum_consensus::state_transition::Error as ConsensusError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]

--- a/mev-build-rs/src/builder/engine_builder.rs
+++ b/mev-build-rs/src/builder/engine_builder.rs
@@ -1,7 +1,7 @@
 use crate::blinded_block_provider::Error as BlindedBlockProviderError;
 use crate::builder::Error;
 use crate::types::{BidRequest as PayloadRequest, ExecutionPayloadWithValue};
-use ethereum_consensus::{
+use beacon_api_client::ethereum_consensus::{
     bellatrix::mainnet::ExecutionPayload,
     builder::SignedValidatorRegistration,
     crypto::SecretKey,

--- a/mev-build-rs/src/builder/error.rs
+++ b/mev-build-rs/src/builder/error.rs
@@ -1,5 +1,5 @@
 use crate::types::BidRequest as PayloadRequest;
-use ethereum_consensus::primitives::BlsPublicKey;
+use beacon_api_client::ethereum_consensus::primitives::BlsPublicKey;
 use thiserror::Error;
 
 #[derive(Debug, Error)]

--- a/mev-build-rs/src/lib.rs
+++ b/mev-build-rs/src/lib.rs
@@ -5,16 +5,16 @@ mod serde;
 mod signing;
 mod types;
 
+use beacon_api_client::ethereum_consensus::{
+    clock::{self, SystemTimeProvider},
+    state_transition::Context,
+};
 pub use blinded_block_provider::{BlindedBlockProvider, Error as BlindedBlockProviderError};
 #[cfg(feature = "api")]
 pub use blinded_block_provider::{
     Client as BlindedBlockProviderClient, Server as BlindedBlockProviderServer,
 };
 pub use builder::{EngineBuilder, Error as BuilderError};
-use ethereum_consensus::{
-    clock::{self, SystemTimeProvider},
-    state_transition::Context,
-};
 pub use signing::{
     sign_builder_message, verify_signed_builder_message, verify_signed_consensus_message,
 };

--- a/mev-build-rs/src/lib.rs
+++ b/mev-build-rs/src/lib.rs
@@ -5,6 +5,8 @@ mod serde;
 mod signing;
 mod types;
 
+pub use beacon_api_client;
+pub use beacon_api_client::ethereum_consensus;
 use beacon_api_client::ethereum_consensus::{
     clock::{self, SystemTimeProvider},
     state_transition::Context,

--- a/mev-build-rs/src/lib.rs
+++ b/mev-build-rs/src/lib.rs
@@ -20,6 +20,7 @@ pub use builder::{EngineBuilder, Error as BuilderError};
 pub use signing::{
     sign_builder_message, verify_signed_builder_message, verify_signed_consensus_message,
 };
+pub use ssz_rs;
 pub use types::*;
 
 #[derive(Default, Debug, Clone, Copy)]

--- a/mev-build-rs/src/serde.rs
+++ b/mev-build-rs/src/serde.rs
@@ -1,1 +1,1 @@
-pub(crate) use ethereum_consensus::serde::as_string;
+pub(crate) use beacon_api_client::ethereum_consensus::serde::as_string;

--- a/mev-build-rs/src/signing.rs
+++ b/mev-build-rs/src/signing.rs
@@ -1,3 +1,4 @@
+use beacon_api_client::ethereum_consensus;
 use ethereum_consensus::builder::compute_builder_domain;
 use ethereum_consensus::crypto::SecretKey;
 use ethereum_consensus::domains::DomainType;

--- a/mev-build-rs/src/types.rs
+++ b/mev-build-rs/src/types.rs
@@ -1,5 +1,7 @@
-use ethereum_consensus::primitives::{BlsPublicKey, BlsSignature, Hash32, Slot, U256};
-pub use ethereum_consensus::{
+use beacon_api_client::ethereum_consensus::primitives::{
+    BlsPublicKey, BlsSignature, Hash32, Slot, U256,
+};
+pub use beacon_api_client::ethereum_consensus::{
     bellatrix::mainnet::{ExecutionPayload, ExecutionPayloadHeader, SignedBlindedBeaconBlock},
     builder::SignedValidatorRegistration,
 };

--- a/mev-relay-rs/Cargo.toml
+++ b/mev-relay-rs/Cargo.toml
@@ -19,6 +19,6 @@ url = { version = "2.2.2", default-features = false }
 
 serde = { version = "1.0", features = ["derive"] }
 
-beacon-api-client = { git = "https://github.com/sigp/beacon-api-client", rev = "c1ce3f68cb1059f7fad96b89c9bd3b2c6c402513" }
+beacon-api-client = { git = "https://github.com/sigp/beacon-api-client", rev = "68a4eaf4e4f0bddd6d799810f3ed78dc702091c8" }
 
 mev-build-rs = { path = "../mev-build-rs"}

--- a/mev-relay-rs/Cargo.toml
+++ b/mev-relay-rs/Cargo.toml
@@ -19,7 +19,6 @@ url = { version = "2.2.2", default-features = false }
 
 serde = { version = "1.0", features = ["derive"] }
 
-ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "e1188b1" }
-beacon-api-client = { git = "https://github.com/ralexstokes/beacon-api-client", rev = "de34eeb" }
+beacon-api-client = { git = "https://github.com/sigp/beacon-api-client", rev = "c1ce3f68cb1059f7fad96b89c9bd3b2c6c402513" }
 
 mev-build-rs = { path = "../mev-build-rs"}

--- a/mev-relay-rs/src/relay.rs
+++ b/mev-relay-rs/src/relay.rs
@@ -2,8 +2,7 @@ use crate::validator_summary_provider::{
     Error as ValidatorSummaryProviderError, ValidatorSummaryProvider,
 };
 use async_trait::async_trait;
-use beacon_api_client::{Client, ValidatorStatus};
-use ethereum_consensus::{
+use beacon_api_client::ethereum_consensus::{
     builder::ValidatorRegistration,
     clock,
     clock::get_current_unix_time_in_secs,
@@ -11,6 +10,7 @@ use ethereum_consensus::{
     primitives::{BlsPublicKey, Slot, U256},
     state_transition::{Context, Error as ConsensusError},
 };
+use beacon_api_client::{Client, ValidatorStatus};
 use futures::StreamExt;
 use mev_build_rs::{
     sign_builder_message, verify_signed_builder_message, verify_signed_consensus_message,

--- a/mev-relay-rs/src/service.rs
+++ b/mev-relay-rs/src/service.rs
@@ -1,6 +1,6 @@
 use crate::relay::Relay;
+use beacon_api_client::ethereum_consensus::state_transition::Context;
 use beacon_api_client::Client;
-use ethereum_consensus::state_transition::Context;
 use futures::future::join_all;
 use mev_build_rs::{BlindedBlockProviderServer, EngineBuilder, Network};
 use serde::Deserialize;

--- a/mev-relay-rs/src/validator_summary_provider.rs
+++ b/mev-relay-rs/src/validator_summary_provider.rs
@@ -1,5 +1,5 @@
+use beacon_api_client::ethereum_consensus::primitives::{BlsPublicKey, ValidatorIndex};
 use beacon_api_client::{Client, Error as ApiError, StateId, ValidatorStatus, ValidatorSummary};
-use ethereum_consensus::primitives::{BlsPublicKey, ValidatorIndex};
 use std::{collections::HashMap, sync::Mutex};
 use thiserror::Error;
 


### PR DESCRIPTION
Pending on
- [ ] https://github.com/ralexstokes/beacon-api-client/pull/43

Changes:
- Removes the explicit dep `ethereum-consensus`, using the one re-exported by `beacon-api-client`. This should make it easier to update in the future
- Re-exports `ssz_rs`, `beacon-api-client` and `ethereum-consensus` as they are often required to work with the mev crates' public apis