### PR TITLE
chore: patch git deps in root Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ dependencies = [
 [[package]]
 name = "beacon-api-client"
 version = "0.1.0"
-source = "git+https://github.com/ralexstokes/beacon-api-client#911215fd0e335d0b48a0d8c0dce6689402c5c398"
+source = "git+https://github.com/ralexstokes//beacon-api-client?rev=7d5d8dad1648f771573f42585ad8080a45b05689#7d5d8dad1648f771573f42585ad8080a45b05689"
 dependencies = [
  "ethereum-consensus",
  "http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ dependencies = [
 [[package]]
 name = "beacon-api-client"
 version = "0.1.0"
-source = "git+https://github.com/ralexstokes/beacon-api-client?rev=7d5d8dad1648f771573f42585ad8080a45b05689#7d5d8dad1648f771573f42585ad8080a45b05689"
+source = "git+https://github.com/ralexstokes/beacon-api-client#911215fd0e335d0b48a0d8c0dce6689402c5c398"
 dependencies = [
  "ethereum-consensus",
  "http",
@@ -763,7 +763,7 @@ dependencies = [
 [[package]]
 name = "ethereum-consensus"
 version = "0.1.1"
-source = "git+https://github.com/ralexstokes/ethereum-consensus?rev=a8110af76d97bf2bf27fb987a671808fcbdf1834#a8110af76d97bf2bf27fb987a671808fcbdf1834"
+source = "git+https://github.com/ralexstokes//ethereum-consensus?rev=a8110af76d97bf2bf27fb987a671808fcbdf1834#a8110af76d97bf2bf27fb987a671808fcbdf1834"
 dependencies = [
  "async-stream",
  "blst",
@@ -2258,7 +2258,7 @@ dependencies = [
 [[package]]
 name = "ssz-rs"
 version = "0.8.0"
-source = "git+https://github.com/ralexstokes/ssz-rs?rev=cb08f1#cb08f18ca919cc1b685b861d0fa9e2daabe89737"
+source = "git+https://github.com/ralexstokes//ssz-rs?rev=cb08f18ca919cc1b685b861d0fa9e2daabe89737#cb08f18ca919cc1b685b861d0fa9e2daabe89737"
 dependencies = [
  "bitvec",
  "hex",
@@ -2273,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "ssz-rs-derive"
 version = "0.8.0"
-source = "git+https://github.com/ralexstokes/ssz-rs?rev=cb08f1#cb08f18ca919cc1b685b861d0fa9e2daabe89737"
+source = "git+https://github.com/ralexstokes//ssz-rs?rev=cb08f18ca919cc1b685b861d0fa9e2daabe89737#cb08f18ca919cc1b685b861d0fa9e2daabe89737"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ ethereum-consensus = { git = "https://github.com/ralexstokes//ethereum-consensus
 ssz-rs = { git = "https://github.com/ralexstokes//ssz-rs", rev = "cb08f18ca919cc1b685b861d0fa9e2daabe89737" }
 
 [patch."https://github.com/ralexstokes/beacon-api-client"]
-beacon-api-client = { git = "https://github.com/ralexstokes/beacon-api-client", rev = "7d5d8dad1648f771573f42585ad8080a45b05689" }
+beacon-api-client = { git = "https://github.com/ralexstokes//beacon-api-client", rev = "7d5d8dad1648f771573f42585ad8080a45b05689" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,9 @@ members = [
     "mev-build-rs",
     "mev-rs",
 ]
+
+[patch."https://github.com/ralexstokes/ethereum-consensus"]
+ethereum-consensus = { git = "https://github.com/ralexstokes//ethereum-consensus", rev = "a8110af76d97bf2bf27fb987a671808fcbdf1834" }
+
+[patch."https://github.com/ralexstokes/ssz-rs"]
+ssz-rs = { git = "https://github.com/ralexstokes//ssz-rs", rev = "cb08f18ca919cc1b685b861d0fa9e2daabe89737" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ ethereum-consensus = { git = "https://github.com/ralexstokes//ethereum-consensus
 
 [patch."https://github.com/ralexstokes/ssz-rs"]
 ssz-rs = { git = "https://github.com/ralexstokes//ssz-rs", rev = "cb08f18ca919cc1b685b861d0fa9e2daabe89737" }
+
+[patch."https://github.com/ralexstokes/beacon-api-client"]
+beacon-api-client = { git = "https://github.com/ralexstokes/beacon-api-client", rev = "7d5d8dad1648f771573f42585ad8080a45b05689" }

--- a/mev-boost-rs/Cargo.toml
+++ b/mev-boost-rs/Cargo.toml
@@ -17,8 +17,8 @@ url = { version = "2.2.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0.30"
 
-ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "a8110af76d97bf2bf27fb987a671808fcbdf1834" }
-beacon-api-client = { git = "https://github.com/ralexstokes/beacon-api-client", rev = "7d5d8dad1648f771573f42585ad8080a45b05689" }
+ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus" }
+beacon-api-client = { git = "https://github.com/ralexstokes/beacon-api-client" }
 
 mev-build-rs = { path = "../mev-build-rs" }
 mev-relay-rs = { path = "../mev-relay-rs" }

--- a/mev-build-rs/Cargo.toml
+++ b/mev-build-rs/Cargo.toml
@@ -19,6 +19,6 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0.81", optional = true }
 thiserror = "1.0.30"
 
-ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "a8110af76d97bf2bf27fb987a671808fcbdf1834" }
-beacon-api-client = { git = "https://github.com/ralexstokes/beacon-api-client", rev = "7d5d8dad1648f771573f42585ad8080a45b05689", optional = true }
-ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "cb08f1" }
+ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus" }
+beacon-api-client = { git = "https://github.com/ralexstokes/beacon-api-client", optional = true }
+ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs" }

--- a/mev-relay-rs/Cargo.toml
+++ b/mev-relay-rs/Cargo.toml
@@ -19,7 +19,7 @@ url = { version = "2.2.2", default-features = false }
 
 serde = { version = "1.0", features = ["derive"] }
 
-ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "a8110af76d97bf2bf27fb987a671808fcbdf1834" }
-beacon-api-client = { git = "https://github.com/ralexstokes/beacon-api-client", rev = "7d5d8dad1648f771573f42585ad8080a45b05689" }
+ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus" }
+beacon-api-client = { git = "https://github.com/ralexstokes/beacon-api-client" }
 
 mev-build-rs = { path = "../mev-build-rs"}


### PR DESCRIPTION
patch git deps in `./Cargo.toml` instead of using `rev` everywhere, this makes it easier to update the pinned commit for the entire repo.

note: due to how patching git deps works in cargo itself, the URL must be different. A known hack is to use double slashes `//` to trick cargo both are different