### PR TITLE
refactor(boost): add ServiceHandle future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1410,6 +1410,7 @@ dependencies = [
  "mev-build-rs",
  "mev-relay-rs",
  "parking_lot",
+ "pin-project",
  "rand",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1429,11 +1429,13 @@ dependencies = [
  "axum",
  "beacon-api-client",
  "ethereum-consensus",
+ "hyper",
  "parking_lot",
  "serde",
  "serde_json",
  "ssz-rs",
  "thiserror",
+ "tokio",
  "tracing",
 ]
 
@@ -1448,6 +1450,7 @@ dependencies = [
  "http",
  "mev-build-rs",
  "parking_lot",
+ "pin-project",
  "serde",
  "thiserror",
  "tokio",

--- a/mev-boost-rs/Cargo.toml
+++ b/mev-boost-rs/Cargo.toml
@@ -12,6 +12,7 @@ tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 futures = "0.3.21"
 async-trait = "0.1.53"
+pin-project = "1.0.12"
 
 url = { version = "2.2.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }

--- a/mev-boost-rs/src/service.rs
+++ b/mev-boost-rs/src/service.rs
@@ -64,10 +64,7 @@ impl Service {
             relay_mux_clone.run().await;
         });
 
-        let server = tokio::spawn(async move {
-            let server = BlindedBlockProviderServer::new(host, port, relay_mux);
-            server.run().await;
-        });
+        let server = BlindedBlockProviderServer::new(host, port, relay_mux).spawn();
 
         ServiceHandle { relayer, server }
     }

--- a/mev-boost-rs/src/service.rs
+++ b/mev-boost-rs/src/service.rs
@@ -1,10 +1,10 @@
 use crate::relay_mux::RelayMux;
 use beacon_api_client::Client;
 use ethereum_consensus::state_transition::Context;
-use futures::future::join_all;
 use mev_build_rs::{BlindedBlockProviderClient as Relay, BlindedBlockProviderServer, Network};
 use serde::Deserialize;
-use std::{net::Ipv4Addr, sync::Arc};
+use std::{future::Future, net::Ipv4Addr, pin::Pin, sync::Arc, task::Poll};
+use tokio::task::{JoinError, JoinHandle};
 use url::Url;
 
 #[derive(Debug, Deserialize)]
@@ -52,23 +52,47 @@ impl Service {
         Self { host: config.host, port: config.port, relays, network }
     }
 
-    pub async fn run(&self) {
+    /// Spawns a new [`RelayMux`] and [`BlindedBlockProviderServer`] task
+    pub fn spawn(self) -> ServiceHandle {
+        let Self { host, port, relays, network } = self;
         let context: Context = self.network.into();
-        let relays = self.relays.iter().cloned().map(|endpoint| Relay::new(Client::new(endpoint)));
-        let relay_mux = RelayMux::new(relays, Arc::new(context), self.network);
-
-        let mut tasks = vec![];
+        let relays = relays.into_iter().map(|endpoint| Relay::new(Client::new(endpoint)));
+        let relay_mux = RelayMux::new(relays, Arc::new(context), network);
 
         let relay_mux_clone = relay_mux.clone();
-        tasks.push(tokio::spawn(async move {
+        let relayer = tokio::spawn(async move {
             relay_mux_clone.run().await;
-        }));
+        });
 
-        let builder_api = BlindedBlockProviderServer::new(self.host, self.port, relay_mux);
-        tasks.push(tokio::spawn(async move {
-            builder_api.run().await;
-        }));
+        let server = tokio::spawn(async move {
+            let server = BlindedBlockProviderServer::new(host, port, relay_mux);
+            server.run().await;
+        });
 
-        join_all(tasks).await;
+        ServiceHandle { relayer, server }
+    }
+}
+
+/// Contains the handles to spawned [`RelayMux`] and [`BlindedBlockProviderServer`] tasks
+///
+/// This struct is created by the [`Service::spawn`] function
+#[pin_project::pin_project]
+pub struct ServiceHandle {
+    #[pin]
+    relayer: JoinHandle<()>,
+    #[pin]
+    server: JoinHandle<()>,
+}
+
+impl Future for ServiceHandle {
+    type Output = Result<(), JoinError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let relayer = this.relayer.poll(cx);
+        if relayer.is_ready() {
+            return relayer
+        }
+        this.server.poll(cx)
     }
 }

--- a/mev-boost-rs/tests/integration.rs
+++ b/mev-boost-rs/tests/integration.rs
@@ -104,7 +104,7 @@ async fn test_end_to_end() {
 
     let mux_port = config.port;
     let service = Service::from(config, Default::default());
-    tokio::spawn(async move { service.run().await });
+    service.spawn();
 
     // let other tasks run so servers boot before we proceed
     // NOTE: there are more races amongst the various services as we add more

--- a/mev-build-rs/Cargo.toml
+++ b/mev-build-rs/Cargo.toml
@@ -9,10 +9,12 @@ rust-version = "1.60.0"
 
 [features]
 default = ["serde", "api", "serde_json"]
-api = ["axum", "beacon-api-client", "tracing"]
+api = ["tokio", "axum", "hyper","beacon-api-client", "tracing"]
 
 [dependencies]
+tokio = { version = "1.0", optional = true }
 axum = { version =  "0.5.4", optional = true }
+hyper = { version = "0.14", optional = true }
 tracing = { version = "0.1", optional = true }
 async-trait = "0.1.53"
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/mev-relay-rs/Cargo.toml
+++ b/mev-relay-rs/Cargo.toml
@@ -13,6 +13,7 @@ tracing = "0.1"
 futures = "0.3.21"
 async-trait = "0.1.53"
 parking_lot = "0.12.1"
+pin-project = "1.0.12"
 
 thiserror = "1.0.30"
 http = "0.2.7"

--- a/mev-relay-rs/src/service.rs
+++ b/mev-relay-rs/src/service.rs
@@ -50,11 +50,11 @@ impl Service {
         let block_provider = relay.clone();
         let server = BlindedBlockProviderServer::new(self.host, self.port, block_provider).spawn();
 
-        let relayer = tokio::spawn(async move {
+        let relay = tokio::spawn(async move {
             relay.run().await;
         });
 
-        ServiceHandle { relayer, server }
+        ServiceHandle { relay, server }
     }
 }
 
@@ -64,7 +64,7 @@ impl Service {
 #[pin_project::pin_project]
 pub struct ServiceHandle {
     #[pin]
-    relayer: JoinHandle<()>,
+    relay: JoinHandle<()>,
     #[pin]
     server: JoinHandle<()>,
 }
@@ -74,9 +74,9 @@ impl Future for ServiceHandle {
 
     fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
-        let relayer = this.relayer.poll(cx);
-        if relayer.is_ready() {
-            return relayer
+        let relay = this.relay.poll(cx);
+        if relay.is_ready() {
+            return relay
         }
         this.server.poll(cx)
     }

--- a/mev-rs/src/boost.rs
+++ b/mev-rs/src/boost.rs
@@ -18,8 +18,7 @@ impl Command {
         let config = Config::from_toml_file(config_file)?;
 
         if let Some(config) = config.boost {
-            Service::from(config, network).run().await;
-            Ok(())
+            Ok(Service::from(config, network).spawn().await?)
         } else {
             Err(anyhow!("missing boost config from file provided"))
         }

--- a/mev-rs/src/relay.rs
+++ b/mev-rs/src/relay.rs
@@ -33,7 +33,7 @@ impl Command {
 
         if let Some(config) = config.relay {
             // TODO separate mock and "real" modes
-            Service::from(config, network).run().await;
+            Service::from(config, network).spawn().await;
             Ok(())
         } else {
             Err(anyhow!("missing relay config from file provided"))

--- a/mev-rs/src/relay.rs
+++ b/mev-rs/src/relay.rs
@@ -33,8 +33,8 @@ impl Command {
 
         if let Some(config) = config.relay {
             // TODO separate mock and "real" modes
-            Service::from(config, network).spawn().await;
-            Ok(())
+            let service = Service::from(config, network).spawn().await;
+            Ok(service.await?)
         } else {
             Err(anyhow!("missing relay config from file provided"))
         }


### PR DESCRIPTION
* rename `async fn Service::run` to `fn Service::spawn() -> ServiceHandle`

* add `ServiceHandle` Future that waits for both task to finish

since this launches the server this could be improved to wait until the server is up, but can tackle that after looking at `BlindedBlockProviderServer`, so perhaps this PR is premature