### PR TITLE
Fix bug in blinded block provider client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Run tests
         run: cargo test --all --lib --verbose
 
+      - name: Run integration tests
+        run: cargo test --all --test '*'
+
       - name: Validate config
         run: cargo run config example.config.toml
 

--- a/mev-rs/src/blinded_block_provider/api/client.rs
+++ b/mev-rs/src/blinded_block_provider/api/client.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use axum::http::StatusCode;
 use beacon_api_client::{
-    api_error_or_ok, ApiResult, Client as BeaconApiClient, Error as BeaconApiError, Value,
+    api_error_or_ok, ApiResult, Client as BeaconApiClient, Error as BeaconApiError, VersionedValue,
 };
 
 /// A `Client` for a service implementing the Builder APIs.
@@ -51,10 +51,10 @@ impl Client {
             return Err(Error::NoBidPrepared(Box::new(bid_request.clone())))
         }
 
-        let result: ApiResult<Value<SignedBuilderBid>> =
+        let result: ApiResult<VersionedValue<SignedBuilderBid>> =
             response.json().await.map_err(beacon_api_client::Error::Http)?;
         match result {
-            ApiResult::Ok(result) => Ok(result.data),
+            ApiResult::Ok(result) => Ok(result.payload),
             ApiResult::Err(err) => Err(err.into()),
         }
     }
@@ -65,8 +65,8 @@ impl Client {
     ) -> Result<ExecutionPayload, Error> {
         let response = self.api.http_post("/eth/v1/builder/blinded_blocks", signed_block).await?;
 
-        let response: Value<ExecutionPayload> =
+        let response: VersionedValue<ExecutionPayload> =
             response.json().await.map_err(|err| -> Error { BeaconApiError::Http(err).into() })?;
-        Ok(response.data)
+        Ok(response.payload)
     }
 }


### PR DESCRIPTION
The changes in #68 for polymorphic types across the builder APIs via the `blinded_block_provider` types missed the update for the `Client`.

This PR updates the types correctly so the responses are parsed as expected, and adds the integration tests to the CI so we can avoid this type of error in the future. If the integration tests become too heavy to run on each CI run, this decision can be revisited.