### PR TITLE
Pass In Genesis Time To Clock

### DIFF
--- a/mev-build-rs/src/service.rs
+++ b/mev-build-rs/src/service.rs
@@ -63,7 +63,7 @@ impl Service {
 
         let context =
             if let Some(context) = context { context } else { Context::try_from(&network)? };
-        let clock = context.clock(None);
+        let clock = context.clock(Option::from(genesis_details.genesis_time));
         let context = Arc::new(context);
         let (tx, rx) = mpsc::channel(BUILD_JOB_BUFFER_SIZE);
         let engine_api_client = EngineApiClient::new(&engine_api_proxy.engine_api_endpoint);


### PR DESCRIPTION
Without passing in the genesis time, the clock would instead use the `MIN_GENESIS_TIME` + `GENESIS_DELAY` . Given that we already know of genesis here in 

```rs
        let genesis_details = client.get_genesis_details().await?;
```

We can simply pass in the fetched genesis time into the clock so that it is able to tick accurately.