### PR TITLE
Fix dependencies patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ dependencies = [
 [[package]]
 name = "beacon-api-client"
 version = "0.1.0"
-source = "git+https://github.com/ralexstokes//beacon-api-client?rev=53690a711e33614d59d4d44fb09762b4699e2a4e#53690a711e33614d59d4d44fb09762b4699e2a4e"
+source = "git+https://github.com/ralexstokes/beacon-api-client.git?rev=53690a711e33614d59d4d44fb09762b4699e2a4e?rev=53690a711e33614d59d4d44fb09762b4699e2a4e#53690a711e33614d59d4d44fb09762b4699e2a4e"
 dependencies = [
  "ethereum-consensus",
  "http",
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "ethereum-consensus"
 version = "0.1.1"
-source = "git+https://github.com/ralexstokes//ethereum-consensus?rev=ef89b4a#ef89b4a4ef97cdd53a66ddb52e554667aca0beb2"
+source = "git+https://github.com/ralexstokes/ethereum-consensus.git?rev=ef89b4a?rev=ef89b4a#ef89b4a4ef97cdd53a66ddb52e554667aca0beb2"
 dependencies = [
  "async-stream",
  "blst",
@@ -2404,7 +2404,7 @@ dependencies = [
 [[package]]
 name = "ssz-rs"
 version = "0.8.0"
-source = "git+https://github.com/ralexstokes//ssz-rs?rev=45ff6f1#45ff6f19ad155657de6bbd32257257154adfcd9f"
+source = "git+https://github.com/ralexstokes/ssz-rs.git?rev=45ff6f1?rev=45ff6f1#45ff6f19ad155657de6bbd32257257154adfcd9f"
 dependencies = [
  "bitvec",
  "hex",
@@ -2418,7 +2418,7 @@ dependencies = [
 [[package]]
 name = "ssz-rs-derive"
 version = "0.8.0"
-source = "git+https://github.com/ralexstokes//ssz-rs?rev=45ff6f1#45ff6f19ad155657de6bbd32257257154adfcd9f"
+source = "git+https://github.com/ralexstokes/ssz-rs.git?rev=45ff6f1?rev=45ff6f1#45ff6f19ad155657de6bbd32257257154adfcd9f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ members = [
 default-members = ["bin/mev"]
 
 [patch."https://github.com/ralexstokes/ethereum-consensus"]
-ethereum-consensus = { git = "https://github.com/ralexstokes//ethereum-consensus", rev = "ef89b4a" }
+ethereum-consensus = { git = "https://github.com:443/ralexstokes/ethereum-consensus.git?rev=ef89b4a", rev = "ef89b4a" }
 
 [patch."https://github.com/ralexstokes/ssz-rs"]
-ssz-rs = { git = "https://github.com/ralexstokes//ssz-rs", rev = "45ff6f1" }
+ssz-rs = { git = "https://github.com:443/ralexstokes/ssz-rs.git?rev=45ff6f1", rev = "45ff6f1" }
 
 [patch."https://github.com/ralexstokes/beacon-api-client"]
-beacon-api-client = { git = "https://github.com/ralexstokes//beacon-api-client", rev = "53690a711e33614d59d4d44fb09762b4699e2a4e" }
+beacon-api-client = { git = "https://github.com:443/ralexstokes/beacon-api-client.git?rev=53690a711e33614d59d4d44fb09762b4699e2a4e", rev = "53690a711e33614d59d4d44fb09762b4699e2a4e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ members = [
 default-members = ["bin/mev"]
 
 [patch."https://github.com/ralexstokes/ethereum-consensus"]
-ethereum-consensus = { git = "https://github.com:443/ralexstokes/ethereum-consensus.git?rev=ef89b4a", rev = "ef89b4a" }
+ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus.git?rev=ef89b4a", rev = "ef89b4a" }
 
 [patch."https://github.com/ralexstokes/ssz-rs"]
-ssz-rs = { git = "https://github.com:443/ralexstokes/ssz-rs.git?rev=45ff6f1", rev = "45ff6f1" }
+ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs.git?rev=45ff6f1", rev = "45ff6f1" }
 
 [patch."https://github.com/ralexstokes/beacon-api-client"]
-beacon-api-client = { git = "https://github.com:443/ralexstokes/beacon-api-client.git?rev=53690a711e33614d59d4d44fb09762b4699e2a4e", rev = "53690a711e33614d59d4d44fb09762b4699e2a4e" }
+beacon-api-client = { git = "https://github.com/ralexstokes/beacon-api-client.git?rev=53690a711e33614d59d4d44fb09762b4699e2a4e", rev = "53690a711e33614d59d4d44fb09762b4699e2a4e" }


### PR DESCRIPTION
With `Cargo 1.66.0 (d65d197ad 2022-11-15)` the current dependencies patch is failing with:

```
rust-analyzer failed to load workspace: Failed to read Cargo metadata from Cargo.toml file /Users/haythem96/Projects/MEV/mev-rs/Cargo.toml, Some(Version { major: 1, minor: 67, patch: 1 }): Failed to run `"cargo" "metadata" "--format-version" "1" "--manifest-path" "/Users/haythem96/Projects/MEV/mev-rs/Cargo.toml" "--filter-platform" "x86_64-apple-darwin"`: `cargo metadata` exited with an error:     Updating git repository `https://github.com/ralexstokes//ethereum-consensus`
warning: spurious network error (2 tries remaining): remote error: 
  ralexstokes//ethereum-consensus is not a valid repository name
  Visit https://support.github.com/ for help; class=Net (12)
warning: spurious network error (1 tries remaining): remote error: 
  ralexstokes//ethereum-consensus is not a valid repository name
  Visit https://support.github.com/ for help; class=Net (12)
error: failed to load source for dependency `ethereum-consensus`

Caused by:
  Unable to update https://github.com/ralexstokes//ethereum-consensus?rev=ef89b4a#ef89b4a4

Caused by:
  failed to fetch into: /Users/haythem96/.cargo/git/db/ethereum-consensus-70d123a531568296

Caused by:
  failed to authenticate when downloading repository: ssh://git@github.com/ralexstokes//ethereum-consensus

  * attempted ssh-agent authentication, but no usernames succeeded: `git`

  if the git CLI succeeds then `net.git-fetch-with-cli` may help here
  https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli

Caused by:
  remote error: 
    ralexstokes//ethereum-consensus is not a valid repository name
    Visit https://support.github.com/ for help; class=Net (12)
```

The same error for the other 2 patched dependencies.

The changes in the PR is a workaround instead of the double `/`