### PR TITLE
Add Checking of Bid Public Keys

### DIFF
--- a/mev-boost-rs/Cargo.toml
+++ b/mev-boost-rs/Cargo.toml
@@ -17,6 +17,7 @@ url = { version = "2.2.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0.30"
 parking_lot = "0.12.1"
+hex = "0.4.3"
 
 ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus" }
 beacon-api-client = { git = "https://github.com/ralexstokes/beacon-api-client" }

--- a/mev-boost-rs/src/lib.rs
+++ b/mev-boost-rs/src/lib.rs
@@ -1,3 +1,4 @@
+mod relay_entry;
 mod relay_mux;
 mod service;
 

--- a/mev-boost-rs/src/relay_entry.rs
+++ b/mev-boost-rs/src/relay_entry.rs
@@ -1,0 +1,131 @@
+use beacon_api_client::Client as BeaconApiClient;
+use ethereum_consensus::primitives::BlsPublicKey;
+use mev_rs::{blinded_block_provider::Client as RelayClient, Error as RelayError};
+use std::str::FromStr;
+use url::Url;
+
+//TODO: rename to relay and change type alias in relayMux etc.
+#[derive(Clone)]
+pub struct RelayEntry {
+    pub api: RelayClient,
+    pub public_key: BlsPublicKey,
+}
+
+impl RelayEntry {
+    pub fn new(endpoint: Url, public_key: BlsPublicKey) -> Self {
+        let client_api = BeaconApiClient::new(endpoint);
+        Self { api: RelayClient::new(client_api, public_key.clone()), public_key }
+    }
+}
+
+impl TryFrom<Url> for RelayEntry {
+    type Error = RelayError;
+
+    fn try_from(url: Url) -> Result<Self, Self::Error> {
+        if url.username().is_empty() || url.username().len() < 48 {
+            return Err(RelayError::RelayUrlPublicKeyError(url, "public key field of relay URL is incorrectly formed: public key is 48 characters in length".to_string()));
+        }
+
+        match hex::decode(url.username()) {
+            Ok(hex) => match BlsPublicKey::try_from(hex.as_ref()) {
+                Ok(public_key) => Ok(Self::new(url, public_key)),
+                Err(e) => Err(RelayError::RelayUrlPublicKeyError(
+                    url,
+                    format!("unable to parse hex data to public key {e}"),
+                )),
+            },
+            Err(e) => Err(RelayError::RelayUrlPublicKeyError(
+                url,
+                format!("unable to decode public key hex data {e}"),
+            )),
+        }
+    }
+}
+
+impl TryFrom<&String> for RelayEntry {
+    type Error = RelayError;
+
+    fn try_from(str: &String) -> Result<Self, Self::Error> {
+        match Url::parse(str) {
+            Ok(url) => RelayEntry::try_from(url),
+            Err(e) => Err(RelayError::RelayUrlParseError(str.to_owned(), e)),
+        }
+    }
+}
+
+impl FromStr for RelayEntry {
+    type Err = RelayError;
+
+    fn from_str(str: &str) -> Result<Self, Self::Err> {
+        match Url::parse(str) {
+            Ok(url) => RelayEntry::try_from(url),
+            Err(e) => Err(RelayError::RelayUrlParseError(String::from(str), e)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_relay_from_str_url() {
+        let test_url = format!(
+            "http://{0}@127.0.0.1:5555",
+            BlsPublicKey::default().to_string().replace("0x", "")
+        );
+        let result = RelayEntry::from_str(&test_url).unwrap();
+        let expected = RelayEntry {
+            api: RelayClient::new(
+                BeaconApiClient::new(Url::parse(&test_url).unwrap()),
+                BlsPublicKey::default(),
+            ),
+            public_key: BlsPublicKey::default(),
+        };
+        //TODO: BeaconApiClient does not implement Eq -> change this to allow us to derive Eq
+        assert_eq!(result.public_key, expected.public_key);
+    }
+
+    #[test]
+    fn test_parse_relay_try_from_string_url() {
+        let test_url = format!(
+            "http://{0}@127.0.0.1:5555",
+            BlsPublicKey::default().to_string().replace("0x", "")
+        );
+        let result = RelayEntry::try_from(&test_url).unwrap();
+        let expected = RelayEntry {
+            api: RelayClient::new(
+                BeaconApiClient::new(Url::parse(&test_url).unwrap()),
+                BlsPublicKey::default(),
+            ),
+            public_key: BlsPublicKey::default(),
+        };
+        //TODO: BeaconApiClient does not implement Eq -> change this to allow us to derive Eq
+        assert_eq!(result.public_key, expected.public_key);
+    }
+
+    #[test]
+    fn test_url_parse_errors_url() {
+        let public_key = "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001";
+        let long_public_key = "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000011";
+        let short_public_key = "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001";
+        let http = "http://";
+        let url = "@127.0.0.1:5555";
+        let bad_url = "@127.0.0.1:555a";
+
+        let test_cases = [
+            format!(""),
+            format!("{http}{url}"),
+            format!("{http}{long_public_key}{url}"),
+            format!("{http}{short_public_key}{url}"),
+            format!("{http}{public_key}{bad_url}"),
+        ];
+
+        for input in test_cases.into_iter() {
+            let output = RelayEntry::try_from(&input);
+            //TODO: Implement PartialEq/Eq for BeaconApiClient to test returned Errors of
+            // RelayEntry via assert_eq!()
+            assert!(output.is_err());
+        }
+    }
+}

--- a/mev-boost-rs/src/relay_mux.rs
+++ b/mev-boost-rs/src/relay_mux.rs
@@ -185,7 +185,7 @@ impl BlindedBlockProvider for RelayMux {
                 Ok(payload) => {
                     let block_hash = payload.block_hash();
                     if block_hash == expected_block_hash {
-                        return Ok(payload);
+                        return Ok(payload)
                     } else {
                         tracing::warn!("error opening bid from relay {i}: the returned payload with block hash {block_hash} did not match the expected block hash: {expected_block_hash}");
                     }

--- a/mev-boost-rs/src/service.rs
+++ b/mev-boost-rs/src/service.rs
@@ -1,22 +1,17 @@
-use crate::relay_mux::RelayMux;
-use beacon_api_client::Client;
-use ethereum_consensus::{primitives::BlsPublicKey, state_transition::Context};
+use crate::{relay_entry::RelayEntry, relay_mux::RelayMux};
+
+use ethereum_consensus::state_transition::Context;
 use futures::StreamExt;
-use mev_rs::{
-    blinded_block_provider::{Client as Relay, Server as BlindedBlockProviderServer},
-    Error, Network,
-};
+use mev_rs::{blinded_block_provider::Server as BlindedBlockProviderServer, Error, Network};
 use serde::Deserialize;
 use std::{future::Future, net::Ipv4Addr, pin::Pin, task::Poll};
 use tokio::task::{JoinError, JoinHandle};
-use url::Url;
 
 #[derive(Debug, Deserialize)]
 pub struct Config {
     pub host: Ipv4Addr,
     pub port: u16,
     pub relays: Vec<String>,
-    pub public_keys: Vec<String>,
     #[serde(default)]
     pub network: Network,
 }
@@ -27,52 +22,37 @@ impl Default for Config {
             host: Ipv4Addr::UNSPECIFIED,
             port: 18550,
             relays: vec![],
-            public_keys: vec![],
             network: Network::default(),
         }
-    }
-}
-
-fn parse_url(input: &str) -> Option<Url> {
-    if input.is_empty() {
-        None
-    } else {
-        input
-            .parse()
-            .map_err(|err| {
-                tracing::warn!("error parsing relay from URL: `{err}`");
-                err
-            })
-            .ok()
-    }
-}
-
-//TODO: Implement Parse for BlsPublicKey in ethereum_consensus
-fn parse_public_key(input: &str) -> Option<BlsPublicKey> {
-    if input.is_empty() {
-        None
-    } else {
-        Some(BlsPublicKey::default())
     }
 }
 
 pub struct Service {
     host: Ipv4Addr,
     port: u16,
-    relays: Vec<(Url, BlsPublicKey)>,
+    relays: Vec<RelayEntry>,
     network: Network,
 }
 
 impl Service {
     pub fn from(config: Config) -> Self {
-        let relays: Vec<Url> = config.relays.iter().filter_map(|s| parse_url(s)).collect();
+        let relays: Vec<RelayEntry> = config
+            .relays
+            .iter()
+            .filter_map(|s| match RelayEntry::try_from(s) {
+                Ok(relay_entry) => Some(relay_entry),
+                Err(e) => {
+                    tracing::error!(
+                        "relay string invalid; please restart with correct configuration: `{e}`"
+                    );
+                    None
+                }
+            })
+            .collect();
+
         if relays.is_empty() {
             tracing::error!("no valid relays provided; please restart with correct configuration");
         }
-
-        let public_keys: Vec<BlsPublicKey> =
-            config.public_keys.iter().filter_map(|p| parse_public_key(p)).collect();
-        let relays = relays.into_iter().zip(public_keys).collect();
 
         Self { host: config.host, port: config.port, relays, network: config.network }
     }
@@ -82,11 +62,8 @@ impl Service {
         let Self { host, port, relays, network } = self;
         let context =
             if let Some(context) = context { context } else { Context::try_from(&network)? };
-        let relays = relays
-            .into_iter()
-            .map(|(endpoint, public_key)| Relay::new(Client::new(endpoint), public_key));
         let clock = context.clock(None);
-        let relay_mux = RelayMux::new(relays, context);
+        let relay_mux = RelayMux::new(relays.into_iter(), context);
 
         let relay_mux_clone = relay_mux.clone();
         let relay_task = tokio::spawn(async move {
@@ -123,7 +100,7 @@ impl Future for ServiceHandle {
         let this = self.project();
         let relay_mux = this.relay_mux.poll(cx);
         if relay_mux.is_ready() {
-            return relay_mux;
+            return relay_mux
         }
         this.server.poll(cx)
     }

--- a/mev-boost-rs/tests/integration.rs
+++ b/mev-boost-rs/tests/integration.rs
@@ -111,7 +111,7 @@ async fn test_end_to_end() {
     // add relay to config
     let mut mux_config = MuxConfig::default();
     //TODO: eliminate this hard coded value by exposing the public key of Relay
-    let relay_public_key = "aa1a1c26055a329817a5759d877a2795f9499b97d6056edde0eea39512f24e8bc874b4471f0501127abb1ea0d9f68ac1";
+    let relay_public_key = "0xaa1a1c26055a329817a5759d877a2795f9499b97d6056edde0eea39512f24e8bc874b4471f0501127abb1ea0d9f68ac1";
     mux_config.relays.push(format!("http://{relay_public_key}@127.0.0.1:{port}"));
 
     //start mux server

--- a/mev-boost-rs/tests/integration.rs
+++ b/mev-boost-rs/tests/integration.rs
@@ -5,7 +5,7 @@ use ethereum_consensus::{
     capella::mainnet as capella,
     crypto::SecretKey,
     phase0::mainnet::{compute_domain, Validator},
-    primitives::{DomainType, ExecutionAddress, Hash32},
+    primitives::{BlsPublicKey, DomainType, ExecutionAddress, Hash32},
     signing::sign_with_domain,
     state_transition::{Context, Forks},
 };
@@ -116,9 +116,10 @@ async fn test_end_to_end() {
     let service = Service::from(config);
     service.spawn(Some(context.clone())).unwrap();
 
-    let beacon_node = RelayClient::new(ApiClient::new(
-        Url::parse(&format!("http://127.0.0.1:{mux_port}")).unwrap(),
-    ));
+    let beacon_node = RelayClient::new(
+        ApiClient::new(Url::parse(&format!("http://127.0.0.1:{mux_port}")).unwrap()),
+        BlsPublicKey::default(),
+    );
 
     beacon_node.check_status().await.unwrap();
 

--- a/mev-relay-rs/src/service.rs
+++ b/mev-relay-rs/src/service.rs
@@ -95,7 +95,7 @@ impl Future for ServiceHandle {
         let this = self.project();
         let relay = this.relay.poll(cx);
         if relay.is_ready() {
-            return relay
+            return relay;
         }
         this.server.poll(cx)
     }

--- a/mev-relay-rs/src/service.rs
+++ b/mev-relay-rs/src/service.rs
@@ -95,7 +95,7 @@ impl Future for ServiceHandle {
         let this = self.project();
         let relay = this.relay.poll(cx);
         if relay.is_ready() {
-            return relay;
+            return relay
         }
         this.server.poll(cx)
     }

--- a/mev-rs/Cargo.toml
+++ b/mev-rs/Cargo.toml
@@ -21,6 +21,7 @@ async-trait = "0.1.53"
 serde = { version = "1.0", features = ["derive"], optional = true }
 thiserror = "1.0.30"
 parking_lot = "0.12.1"
+url = { version = "2.2.2", default-features = false }
 
 anvil-rpc = { git = "https://github.com/foundry-rs/foundry", rev = "b45456717ffae1af65acdc71099f8cb95e6683a0", optional = true}
 reqwest = { version = "0.11.14", optional = true }

--- a/mev-rs/src/blinded_block_provider/api/client.rs
+++ b/mev-rs/src/blinded_block_provider/api/client.rs
@@ -9,6 +9,7 @@ use axum::http::StatusCode;
 use beacon_api_client::{
     api_error_or_ok, ApiResult, Client as BeaconApiClient, Error as ApiError, VersionedValue,
 };
+use ethereum_consensus::primitives::BlsPublicKey;
 
 /// A `Client` for a service implementing the Builder APIs.
 /// Note that `Client` does not implement the `Builder` trait so that
@@ -17,11 +18,12 @@ use beacon_api_client::{
 #[derive(Clone)]
 pub struct Client {
     api: BeaconApiClient,
+    pub public_key: BlsPublicKey,
 }
 
 impl Client {
-    pub fn new(api_client: BeaconApiClient) -> Self {
-        Self { api: api_client }
+    pub fn new(api_client: BeaconApiClient, bls_public_key: BlsPublicKey) -> Self {
+        Self { api: api_client, public_key: bls_public_key }
     }
 
     pub async fn check_status(&self) -> Result<(), beacon_api_client::Error> {
@@ -48,7 +50,7 @@ impl Client {
         let response = self.api.http_get(&target).await?;
 
         if response.status() == StatusCode::NO_CONTENT {
-            return Err(Error::NoBidPrepared(Box::new(bid_request.clone())))
+            return Err(Error::NoBidPrepared(Box::new(bid_request.clone())));
         }
 
         let result: ApiResult<VersionedValue<SignedBuilderBid>> =

--- a/mev-rs/src/blinded_block_provider/api/client.rs
+++ b/mev-rs/src/blinded_block_provider/api/client.rs
@@ -50,7 +50,7 @@ impl Client {
         let response = self.api.http_get(&target).await?;
 
         if response.status() == StatusCode::NO_CONTENT {
-            return Err(Error::NoBidPrepared(Box::new(bid_request.clone())));
+            return Err(Error::NoBidPrepared(Box::new(bid_request.clone())))
         }
 
         let result: ApiResult<VersionedValue<SignedBuilderBid>> =

--- a/mev-rs/src/error.rs
+++ b/mev-rs/src/error.rs
@@ -5,6 +5,7 @@ use ethereum_consensus::{
     state_transition::Error as ConsensusError,
 };
 use thiserror::Error;
+use url::{ParseError, Url};
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -28,6 +29,8 @@ pub enum Error {
     UnknownBlock,
     #[error("payload request does not match any outstanding bid")]
     UnknownBid,
+    #[error("bid public key is incorrect")]
+    InvalidBidPublicKey,
     #[error("validator {0} does not have {1} fee recipient")]
     UnknownFeeRecipient(BlsPublicKey, ExecutionAddress),
     #[error("validator with public key {0} is not currently registered")]
@@ -43,4 +46,8 @@ pub enum Error {
     #[cfg(feature = "engine-proxy")]
     #[error("{0}")]
     EngineApi(#[from] crate::engine_api_proxy::Error),
+    #[error("unable to parse relay URL {0} as {1}")]
+    RelayUrlParseError(String, ParseError),
+    #[error("unable to parse relay public key from URL {0} due to error: {1}")]
+    RelayUrlPublicKeyError(Url, String),
 }

--- a/mev-rs/src/types/mod.rs
+++ b/mev-rs/src/types/mod.rs
@@ -107,6 +107,13 @@ impl SignedBuilderBid {
         }
     }
 
+    pub fn public_key(&self) -> &BlsPublicKey {
+        match self {
+            Self::Bellatrix(bid) => &bid.message.public_key,
+            Self::Capella(bid) => &bid.message.public_key,
+        }
+    }
+
     pub fn block_hash(&self) -> &Hash32 {
         match self {
             Self::Bellatrix(bid) => &bid.message.header.block_hash,


### PR DESCRIPTION
WIP for  #82 . 

- [x] Extends Relay Client to tracks BlsPublicKeys
- [x] Checks that a Relays BlsPublicKey matches SignedBuilder BlsPublicKey
- [x] Parses BlsPublicKey from Relay Mux config. This should probably involve adding a FromStr implementation to https://github.com/ralexstokes/ethereum-consensus/blob/main/src/crypto.rs on top of the other trait implementations for PublicKey on the next release.