### PR TITLE
Try to pin dependencies in Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,9 +332,9 @@ dependencies = [
 [[package]]
 name = "beacon-api-client"
 version = "0.1.0"
-source = "git+https://github.com/ralexstokes//beacon-api-client?rev=53690a711e33614d59d4d44fb09762b4699e2a4e#53690a711e33614d59d4d44fb09762b4699e2a4e"
+source = "git+https://github.com/ralexstokes/beacon-api-client?rev=53690a711e33614d59d4d44fb09762b4699e2a4e#53690a711e33614d59d4d44fb09762b4699e2a4e"
 dependencies = [
- "ethereum-consensus",
+ "ethereum-consensus 0.1.1 (git+https://github.com/ralexstokes/ethereum-consensus?rev=5531c285fc4030e265b8499612946d8a704e2c57)",
  "http",
  "itertools",
  "reqwest",
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "ethereum-consensus"
 version = "0.1.1"
-source = "git+https://github.com/ralexstokes//ethereum-consensus?rev=ef89b4a#ef89b4a4ef97cdd53a66ddb52e554667aca0beb2"
+source = "git+https://github.com/ralexstokes/ethereum-consensus?rev=46ca1716f2b1651e59b8a565b5bbcadf6b052fa5#46ca1716f2b1651e59b8a565b5bbcadf6b052fa5"
 dependencies = [
  "async-stream",
  "blst",
@@ -815,7 +815,30 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2 0.9.9",
- "ssz-rs",
+ "ssz-rs 0.8.0 (git+https://github.com/ralexstokes/ssz-rs?rev=adf1a0b14cef90b9536f28ef89da1fab316465e1)",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "ethereum-consensus"
+version = "0.1.1"
+source = "git+https://github.com/ralexstokes/ethereum-consensus?rev=5531c285fc4030e265b8499612946d8a704e2c57#5531c285fc4030e265b8499612946d8a704e2c57"
+dependencies = [
+ "async-stream",
+ "blst",
+ "bs58",
+ "enr",
+ "hex",
+ "integer-sqrt",
+ "multiaddr",
+ "multihash",
+ "rand",
+ "serde",
+ "serde_json",
+ "sha2 0.9.9",
+ "ssz-rs 0.8.0 (git+https://github.com/ralexstokes/ssz-rs?rev=5946af4a65a1e8547a8fc7cfb62e12637421b8f2)",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -1500,7 +1523,7 @@ version = "0.3.0"
 dependencies = [
  "async-trait",
  "beacon-api-client",
- "ethereum-consensus",
+ "ethereum-consensus 0.1.1 (git+https://github.com/ralexstokes/ethereum-consensus?rev=46ca1716f2b1651e59b8a565b5bbcadf6b052fa5)",
  "futures",
  "httpmock",
  "mev-build-rs",
@@ -1524,7 +1547,7 @@ version = "0.3.0"
 dependencies = [
  "async-trait",
  "beacon-api-client",
- "ethereum-consensus",
+ "ethereum-consensus 0.1.1 (git+https://github.com/ralexstokes/ethereum-consensus?rev=46ca1716f2b1651e59b8a565b5bbcadf6b052fa5)",
  "futures",
  "mev-rs",
  "parking_lot",
@@ -1542,7 +1565,7 @@ version = "0.3.0"
 dependencies = [
  "async-trait",
  "beacon-api-client",
- "ethereum-consensus",
+ "ethereum-consensus 0.1.1 (git+https://github.com/ralexstokes/ethereum-consensus?rev=46ca1716f2b1651e59b8a565b5bbcadf6b052fa5)",
  "futures",
  "http",
  "mev-build-rs",
@@ -1564,13 +1587,13 @@ dependencies = [
  "async-trait",
  "axum",
  "beacon-api-client",
- "ethereum-consensus",
+ "ethereum-consensus 0.1.1 (git+https://github.com/ralexstokes/ethereum-consensus?rev=46ca1716f2b1651e59b8a565b5bbcadf6b052fa5)",
  "hyper",
  "parking_lot",
  "reqwest",
  "serde",
  "serde_json",
- "ssz-rs",
+ "ssz-rs 0.8.0 (git+https://github.com/ralexstokes/ssz-rs?rev=45ff6f19ad155657de6bbd32257257154adfcd9f)",
  "thiserror",
  "tokio",
  "tracing",
@@ -2404,21 +2427,69 @@ dependencies = [
 [[package]]
 name = "ssz-rs"
 version = "0.8.0"
-source = "git+https://github.com/ralexstokes//ssz-rs?rev=45ff6f1#45ff6f19ad155657de6bbd32257257154adfcd9f"
+source = "git+https://github.com/ralexstokes/ssz-rs?rev=45ff6f19ad155657de6bbd32257257154adfcd9f#45ff6f19ad155657de6bbd32257257154adfcd9f"
 dependencies = [
  "bitvec",
  "hex",
  "num-bigint",
  "serde",
  "sha2 0.9.9",
- "ssz-rs-derive",
+ "ssz-rs-derive 0.8.0 (git+https://github.com/ralexstokes/ssz-rs?rev=45ff6f19ad155657de6bbd32257257154adfcd9f)",
+ "thiserror",
+]
+
+[[package]]
+name = "ssz-rs"
+version = "0.8.0"
+source = "git+https://github.com/ralexstokes/ssz-rs?rev=5946af4a65a1e8547a8fc7cfb62e12637421b8f2#5946af4a65a1e8547a8fc7cfb62e12637421b8f2"
+dependencies = [
+ "bitvec",
+ "hex",
+ "num-bigint",
+ "serde",
+ "sha2 0.9.9",
+ "ssz-rs-derive 0.8.0 (git+https://github.com/ralexstokes/ssz-rs?rev=5946af4a65a1e8547a8fc7cfb62e12637421b8f2)",
+ "thiserror",
+]
+
+[[package]]
+name = "ssz-rs"
+version = "0.8.0"
+source = "git+https://github.com/ralexstokes/ssz-rs?rev=adf1a0b14cef90b9536f28ef89da1fab316465e1#adf1a0b14cef90b9536f28ef89da1fab316465e1"
+dependencies = [
+ "bitvec",
+ "hex",
+ "num-bigint",
+ "serde",
+ "sha2 0.9.9",
+ "ssz-rs-derive 0.8.0 (git+https://github.com/ralexstokes/ssz-rs?rev=adf1a0b14cef90b9536f28ef89da1fab316465e1)",
  "thiserror",
 ]
 
 [[package]]
 name = "ssz-rs-derive"
 version = "0.8.0"
-source = "git+https://github.com/ralexstokes//ssz-rs?rev=45ff6f1#45ff6f19ad155657de6bbd32257257154adfcd9f"
+source = "git+https://github.com/ralexstokes/ssz-rs?rev=45ff6f19ad155657de6bbd32257257154adfcd9f#45ff6f19ad155657de6bbd32257257154adfcd9f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ssz-rs-derive"
+version = "0.8.0"
+source = "git+https://github.com/ralexstokes/ssz-rs?rev=5946af4a65a1e8547a8fc7cfb62e12637421b8f2#5946af4a65a1e8547a8fc7cfb62e12637421b8f2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ssz-rs-derive"
+version = "0.8.0"
+source = "git+https://github.com/ralexstokes/ssz-rs?rev=adf1a0b14cef90b9536f28ef89da1fab316465e1#adf1a0b14cef90b9536f28ef89da1fab316465e1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,5 @@ members = [
 ]
 default-members = ["bin/mev"]
 
-[patch."https://github.com/ralexstokes/ethereum-consensus"]
-ethereum-consensus = { git = "https://github.com/ralexstokes//ethereum-consensus", rev = "ef89b4a" }
-
-[patch."https://github.com/ralexstokes/ssz-rs"]
-ssz-rs = { git = "https://github.com/ralexstokes//ssz-rs", rev = "45ff6f1" }
-
-[patch."https://github.com/ralexstokes/beacon-api-client"]
-beacon-api-client = { git = "https://github.com/ralexstokes//beacon-api-client", rev = "53690a711e33614d59d4d44fb09762b4699e2a4e" }
+# [patch."https://github.com/ralexstokes/beacon-api-client"]
+# beacon-api-client = { path = "../beacon-api-client" }

--- a/mev-boost-rs/Cargo.toml
+++ b/mev-boost-rs/Cargo.toml
@@ -18,8 +18,8 @@ serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0.30"
 parking_lot = "0.12.1"
 
-ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus" }
-beacon-api-client = { git = "https://github.com/ralexstokes/beacon-api-client" }
+ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "46ca1716f2b1651e59b8a565b5bbcadf6b052fa5" }
+beacon-api-client = { git = "https://github.com/ralexstokes/beacon-api-client", rev = "53690a711e33614d59d4d44fb09762b4699e2a4e" }
 
 mev-rs = { path = "../mev-rs" }
 

--- a/mev-build-rs/Cargo.toml
+++ b/mev-build-rs/Cargo.toml
@@ -18,7 +18,7 @@ thiserror = "1.0.30"
 url = { version = "2.2.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 
-ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus" }
-beacon-api-client = { git = "https://github.com/ralexstokes/beacon-api-client" }
+ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "46ca1716f2b1651e59b8a565b5bbcadf6b052fa5" }
+beacon-api-client = { git = "https://github.com/ralexstokes/beacon-api-client", rev = "53690a711e33614d59d4d44fb09762b4699e2a4e" }
 
 mev-rs = { path = "../mev-rs" }

--- a/mev-relay-rs/Cargo.toml
+++ b/mev-relay-rs/Cargo.toml
@@ -19,8 +19,8 @@ http = "0.2.7"
 url = { version = "2.2.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 
-ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus" }
-beacon-api-client = { git = "https://github.com/ralexstokes/beacon-api-client" }
+ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "46ca1716f2b1651e59b8a565b5bbcadf6b052fa5" }
+beacon-api-client = { git = "https://github.com/ralexstokes/beacon-api-client", rev = "53690a711e33614d59d4d44fb09762b4699e2a4e" }
 
 mev-rs = { path = "../mev-rs" }
 mev-build-rs = { path = "../mev-build-rs" }

--- a/mev-rs/Cargo.toml
+++ b/mev-rs/Cargo.toml
@@ -26,6 +26,6 @@ anvil-rpc = { git = "https://github.com/foundry-rs/foundry", rev = "b45456717ffa
 reqwest = { version = "0.11.14", optional = true }
 serde_json = {version =  "1.0.92", optional = true }
 
-ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus" }
-beacon-api-client = { git = "https://github.com/ralexstokes/beacon-api-client", optional = true }
-ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs" }
+ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "46ca1716f2b1651e59b8a565b5bbcadf6b052fa5" }
+beacon-api-client = { git = "https://github.com/ralexstokes/beacon-api-client", optional = true, rev = "53690a711e33614d59d4d44fb09762b4699e2a4e" }
+ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "45ff6f19ad155657de6bbd32257257154adfcd9f" }

--- a/update-git-dep.sh
+++ b/update-git-dep.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+workspace_crates=(bin/mev mev-boost-rs mev-relay-rs mev-build-rs mev-rs)
+
+if [ $# -ne 2 ]
+then
+    echo "Usage: ./$(basename $0) <dependency> <commit>"
+    exit 1
+fi
+
+dependency=$1
+commit=$2
+
+for workspace_crate in ${workspace_crates[@]}
+do
+    echo "updating $dependency dependency of $workspace_crate"
+    sed -i.bak -e "s/^$dependency = \(.*\), *rev *= *\".*\" *}/$dependency = \1, rev = \"$commit\" }/" "$workspace_crate/Cargo.toml"
+    rm -f "$workspace_crate/Cargo.toml.bak"
+done
+


### PR DESCRIPTION
This is an attempt to remove the `[patch]` sections from the top-level `Cargo.toml`. I ran out of steam when it came to updating `beacon-api-client` as it seems that `beacon-api-client` is incompatible with the latest `ethereum-types` due to the refactoring of `MetaData` in https://github.com/ralexstokes/ethereum-consensus/pull/186.