### PR TITLE
add 'group_imports' to rustfmt config

### DIFF
--- a/bin/mev/src/cmd/boost.rs
+++ b/bin/mev/src/cmd/boost.rs
@@ -1,8 +1,9 @@
-use crate::cmd::config::Config;
 use anyhow::{anyhow, Result};
 use clap::Args;
 use mev_boost_rs::Service;
 use mev_rs::Network;
+
+use crate::cmd::config::Config;
 
 #[derive(Debug, Args)]
 #[clap(about = "🚀 connecting proposers to the external builder network")]

--- a/bin/mev/src/cmd/build.rs
+++ b/bin/mev/src/cmd/build.rs
@@ -1,8 +1,9 @@
-use crate::cmd::config::Config;
 use anyhow::{anyhow, Result};
 use clap::{Args, Subcommand};
 use mev_build_rs::Service;
 use mev_rs::Network;
+
+use crate::cmd::config::Config;
 
 #[derive(Debug, Args)]
 #[clap(about = "🛠️ building blocks since 2023", subcommand_negates_reqs = true)]

--- a/bin/mev/src/cmd/config.rs
+++ b/bin/mev/src/cmd/config.rs
@@ -1,3 +1,5 @@
+use std::{fmt, path::Path};
+
 use anyhow::{Context, Result};
 use clap::Args;
 use mev_boost_rs::Config as BoostConfig;
@@ -5,7 +7,6 @@ use mev_build_rs::Config as BuildConfig;
 use mev_relay_rs::Config as RelayConfig;
 use mev_rs::Network;
 use serde::Deserialize;
-use std::{fmt, path::Path};
 
 #[derive(Debug, Deserialize)]
 pub struct Config {

--- a/bin/mev/src/cmd/relay.rs
+++ b/bin/mev/src/cmd/relay.rs
@@ -1,8 +1,9 @@
-use crate::cmd::config::Config;
 use anyhow::{anyhow, Result};
 use clap::{Args, Subcommand};
 use mev_relay_rs::Service;
 use mev_rs::Network;
+
+use crate::cmd::config::Config;
 
 #[derive(Debug, Args)]
 #[clap(about = "🏗 connecting builders to proposers", subcommand_negates_reqs = true)]

--- a/bin/mev/src/main.rs
+++ b/bin/mev/src/main.rs
@@ -1,9 +1,10 @@
 mod cmd;
 
+use std::future::Future;
+
 use anyhow::Result;
 use clap::{ArgGroup, Parser, Subcommand};
 use mev_rs::Network;
-use std::future::Future;
 use tokio::signal;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 

--- a/mev-boost-rs/src/relay_mux.rs
+++ b/mev-boost-rs/src/relay_mux.rs
@@ -1,3 +1,5 @@
+use std::{collections::HashMap, ops::Deref, sync::Arc, time::Duration};
+
 use async_trait::async_trait;
 use ethereum_consensus::{
     primitives::{BlsPublicKey, Slot, U256},
@@ -14,7 +16,6 @@ use mev_rs::{
 };
 use parking_lot::Mutex;
 use rand::prelude::*;
-use std::{collections::HashMap, ops::Deref, sync::Arc, time::Duration};
 
 // See note in the `mev-relay-rs::Relay` about this constant.
 // TODO likely drop this feature...

--- a/mev-boost-rs/src/service.rs
+++ b/mev-boost-rs/src/service.rs
@@ -1,4 +1,5 @@
-use crate::relay_mux::RelayMux;
+use std::{future::Future, net::Ipv4Addr, pin::Pin, task::Poll};
+
 use beacon_api_client::Client;
 use ethereum_consensus::state_transition::Context;
 use futures::StreamExt;
@@ -7,9 +8,10 @@ use mev_rs::{
     Error, Network,
 };
 use serde::Deserialize;
-use std::{future::Future, net::Ipv4Addr, pin::Pin, task::Poll};
 use tokio::task::{JoinError, JoinHandle};
 use url::Url;
+
+use crate::relay_mux::RelayMux;
 
 #[derive(Debug, Deserialize)]
 pub struct Config {

--- a/mev-boost-rs/tests/integration.rs
+++ b/mev-boost-rs/tests/integration.rs
@@ -17,13 +17,11 @@ use mev_rs::{
     signing::sign_builder_message,
     types::{BidRequest, ExecutionPayload, SignedBlindedBeaconBlock, SignedBuilderBid},
 };
-
 use rand::seq::SliceRandom;
 use std::{
     collections::HashMap,
     time::{SystemTime, UNIX_EPOCH},
 };
-
 use url::Url;
 
 fn setup_logging() {

--- a/mev-boost-rs/tests/integration.rs
+++ b/mev-boost-rs/tests/integration.rs
@@ -1,3 +1,8 @@
+use std::{
+    collections::HashMap,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
 use beacon_api_client::{Client as ApiClient, ValidatorStatus, ValidatorSummary, Value};
 use ethereum_consensus::{
     bellatrix::mainnet as bellatrix,
@@ -18,10 +23,6 @@ use mev_rs::{
     types::{BidRequest, ExecutionPayload, SignedBlindedBeaconBlock, SignedBuilderBid},
 };
 use rand::seq::SliceRandom;
-use std::{
-    collections::HashMap,
-    time::{SystemTime, UNIX_EPOCH},
-};
 use url::Url;
 
 fn setup_logging() {

--- a/mev-build-rs/src/mempool_builder.rs
+++ b/mev-build-rs/src/mempool_builder.rs
@@ -1,3 +1,5 @@
+use std::{collections::HashMap, ops::Deref, sync::Arc};
+
 use async_trait::async_trait;
 use beacon_api_client::{BeaconProposerRegistration, Client, ProposerDuty};
 use ethereum_consensus::{
@@ -15,7 +17,6 @@ use mev_rs::{
     BlindedBlockProvider, Error, ProposerScheduler, ValidatorRegistry,
 };
 use parking_lot::Mutex;
-use std::{collections::HashMap, ops::Deref, sync::Arc};
 use tokio::{sync::mpsc, task::JoinHandle};
 
 #[derive(Clone)]

--- a/mev-build-rs/src/service.rs
+++ b/mev-build-rs/src/service.rs
@@ -1,4 +1,5 @@
-use crate::mempool_builder::Builder;
+use std::{fmt, future::Future, net::Ipv4Addr, pin::Pin, sync::Arc, task::Poll};
+
 use beacon_api_client::Client;
 use ethereum_consensus::{crypto::SecretKey, state_transition::Context};
 use futures::StreamExt;
@@ -13,12 +14,13 @@ use mev_rs::{
     Error, Network,
 };
 use serde::Deserialize;
-use std::{fmt, future::Future, net::Ipv4Addr, pin::Pin, sync::Arc, task::Poll};
 use tokio::{
     sync::mpsc,
     task::{JoinError, JoinHandle},
 };
 use url::Url;
+
+use crate::mempool_builder::Builder;
 
 const BUILD_JOB_BUFFER_SIZE: usize = 1;
 

--- a/mev-relay-rs/src/relay.rs
+++ b/mev-relay-rs/src/relay.rs
@@ -1,3 +1,5 @@
+use std::{collections::HashMap, ops::Deref, sync::Arc};
+
 use async_trait::async_trait;
 use beacon_api_client::Client;
 use ethereum_consensus::{
@@ -17,7 +19,6 @@ use mev_rs::{
     BlindedBlockProvider, Error, ValidatorRegistry,
 };
 use parking_lot::Mutex;
-use std::{collections::HashMap, ops::Deref, sync::Arc};
 
 // `PROPOSAL_TOLERANCE_DELAY` controls how aggresively the relay drops "old" execution payloads
 // once they have been fetched from builders -- currently in response to an incoming request from a

--- a/mev-relay-rs/src/service.rs
+++ b/mev-relay-rs/src/service.rs
@@ -1,12 +1,14 @@
-use crate::relay::Relay;
+use std::{future::Future, net::Ipv4Addr, pin::Pin, sync::Arc, task::Poll};
+
 use beacon_api_client::Client;
 use ethereum_consensus::state_transition::Context;
 use futures::StreamExt;
 use mev_rs::{blinded_block_provider::Server as BlindedBlockProviderServer, Error, Network};
 use serde::Deserialize;
-use std::{future::Future, net::Ipv4Addr, pin::Pin, sync::Arc, task::Poll};
 use tokio::task::{JoinError, JoinHandle};
 use url::Url;
+
+use crate::relay::Relay;
 
 #[derive(Debug, Deserialize)]
 pub struct Config {

--- a/mev-rs/src/blinded_block_provider/api/client.rs
+++ b/mev-rs/src/blinded_block_provider/api/client.rs
@@ -1,13 +1,14 @@
+use axum::http::StatusCode;
+use beacon_api_client::{
+    api_error_or_ok, ApiResult, Client as BeaconApiClient, Error as ApiError, VersionedValue,
+};
+
 use crate::{
     blinded_block_provider::Error,
     types::{
         BidRequest, ExecutionPayload, SignedBlindedBeaconBlock, SignedBuilderBid,
         SignedValidatorRegistration,
     },
-};
-use axum::http::StatusCode;
-use beacon_api_client::{
-    api_error_or_ok, ApiResult, Client as BeaconApiClient, Error as ApiError, VersionedValue,
 };
 
 /// A `Client` for a service implementing the Builder APIs.

--- a/mev-rs/src/blinded_block_provider/api/server.rs
+++ b/mev-rs/src/blinded_block_provider/api/server.rs
@@ -1,11 +1,5 @@
-use crate::{
-    blinded_block_provider::BlindedBlockProvider,
-    error::Error,
-    types::{
-        bellatrix, capella, BidRequest, ExecutionPayload, SignedBlindedBeaconBlock,
-        SignedBuilderBid, SignedValidatorRegistration,
-    },
-};
+use std::net::{Ipv4Addr, SocketAddr};
+
 use axum::{
     extract::{Json, Path, State},
     http::StatusCode,
@@ -16,8 +10,16 @@ use axum::{
 use beacon_api_client::{ApiError, Error as ApiClientError, VersionedValue};
 use hyper::server::conn::AddrIncoming;
 use serde::Deserialize;
-use std::net::{Ipv4Addr, SocketAddr};
 use tokio::task::JoinHandle;
+
+use crate::{
+    blinded_block_provider::BlindedBlockProvider,
+    error::Error,
+    types::{
+        bellatrix, capella, BidRequest, ExecutionPayload, SignedBlindedBeaconBlock,
+        SignedBuilderBid, SignedValidatorRegistration,
+    },
+};
 
 /// Type alias for the configured axum server
 pub type BlockProviderServer = axum::Server<AddrIncoming, IntoMakeService<Router>>;

--- a/mev-rs/src/blinded_block_provider/mod.rs
+++ b/mev-rs/src/blinded_block_provider/mod.rs
@@ -1,6 +1,10 @@
 #[cfg(feature = "api")]
 mod api;
 
+use async_trait::async_trait;
+#[cfg(feature = "api")]
+pub use {api::client::Client, api::server::Server};
+
 use crate::{
     error::Error,
     types::{
@@ -8,9 +12,6 @@ use crate::{
         SignedValidatorRegistration,
     },
 };
-use async_trait::async_trait;
-#[cfg(feature = "api")]
-pub use {api::client::Client, api::server::Server};
 
 #[async_trait]
 pub trait BlindedBlockProvider {

--- a/mev-rs/src/blinded_block_provider/mod.rs
+++ b/mev-rs/src/blinded_block_provider/mod.rs
@@ -1,9 +1,6 @@
 #[cfg(feature = "api")]
 mod api;
 
-#[cfg(feature = "api")]
-pub use {api::client::Client, api::server::Server};
-
 use crate::{
     error::Error,
     types::{
@@ -12,6 +9,8 @@ use crate::{
     },
 };
 use async_trait::async_trait;
+#[cfg(feature = "api")]
+pub use {api::client::Client, api::server::Server};
 
 #[async_trait]
 pub trait BlindedBlockProvider {

--- a/mev-rs/src/engine_api_proxy/client.rs
+++ b/mev-rs/src/engine_api_proxy/client.rs
@@ -1,3 +1,11 @@
+use std::sync::Arc;
+
+use anvil_rpc::request::{Id, RequestParams, RpcMethodCall, Version};
+use ethereum_consensus::{capella::Withdrawal, primitives::ValidatorIndex};
+use parking_lot::Mutex;
+use serde::Deserialize;
+use ssz_rs::prelude::U256;
+
 use crate::{
     engine_api_proxy::{
         types::{self, BuildVersion, ExecutionPayloadWithValue, PayloadId},
@@ -5,12 +13,6 @@ use crate::{
     },
     types::{bellatrix, capella, ExecutionPayload},
 };
-use anvil_rpc::request::{Id, RequestParams, RpcMethodCall, Version};
-use ethereum_consensus::{capella::Withdrawal, primitives::ValidatorIndex};
-use parking_lot::Mutex;
-use serde::Deserialize;
-use ssz_rs::prelude::U256;
-use std::sync::Arc;
 
 const ENGINE_GET_PAYLOADV1_METHOD: &str = "engine_getPayloadV1";
 const ENGINE_GET_PAYLOADV2_METHOD: &str = "engine_getPayloadV2";

--- a/mev-rs/src/engine_api_proxy/server.rs
+++ b/mev-rs/src/engine_api_proxy/server.rs
@@ -1,7 +1,8 @@
-use crate::engine_api_proxy::types::{
-    BuildJob, BuildVersion, ForkchoiceUpdatedV1Params, ForkchoiceUpdatedV1Response,
-    ForkchoiceUpdatedV2Params, PayloadAttributes,
+use std::{
+    net::{Ipv4Addr, SocketAddr},
+    sync::Arc,
 };
+
 use axum::{
     extract::State,
     http::{uri::Uri, Request, Response},
@@ -11,11 +12,12 @@ use axum::{
 use hyper::{body, client::HttpConnector, server::conn::AddrIncoming, Body};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
-use std::{
-    net::{Ipv4Addr, SocketAddr},
-    sync::Arc,
-};
 use tokio::{sync::mpsc, task::JoinHandle};
+
+use crate::engine_api_proxy::types::{
+    BuildJob, BuildVersion, ForkchoiceUpdatedV1Params, ForkchoiceUpdatedV1Response,
+    ForkchoiceUpdatedV2Params, PayloadAttributes,
+};
 
 pub type EngineApiProxyServer = axum::Server<AddrIncoming, IntoMakeService<Router>>;
 pub type Client = hyper::client::Client<HttpConnector, Body>;

--- a/mev-rs/src/error.rs
+++ b/mev-rs/src/error.rs
@@ -1,10 +1,11 @@
-use crate::types::BidRequest;
 use beacon_api_client::Error as ApiError;
 use ethereum_consensus::{
     primitives::{BlsPublicKey, ExecutionAddress, Hash32},
     state_transition::Error as ConsensusError,
 };
 use thiserror::Error;
+
+use crate::types::BidRequest;
 
 #[derive(Debug, Error)]
 pub enum Error {

--- a/mev-rs/src/lib.rs
+++ b/mev-rs/src/lib.rs
@@ -11,7 +11,6 @@ pub mod types;
 mod validator_registry;
 
 pub use blinded_block_provider::BlindedBlockProvider;
-
 pub use error::Error;
 pub use network::*;
 pub use proposer_scheduler::ProposerScheduler;

--- a/mev-rs/src/proposer_scheduler.rs
+++ b/mev-rs/src/proposer_scheduler.rs
@@ -1,7 +1,8 @@
+use std::collections::HashMap;
+
 use beacon_api_client::{BeaconProposerRegistration, Client, Error as ApiError, ProposerDuty};
 use ethereum_consensus::primitives::{BlsPublicKey, Epoch, Slot};
 use parking_lot::Mutex;
-use std::collections::HashMap;
 use thiserror::Error;
 
 #[derive(Debug, Error)]

--- a/mev-rs/src/types/mod.rs
+++ b/mev-rs/src/types/mod.rs
@@ -1,9 +1,6 @@
 pub mod bellatrix;
 pub mod capella;
 
-use crate::signing::{
-    sign_builder_message, verify_signed_builder_message, verify_signed_consensus_message,
-};
 pub use ethereum_consensus::builder::SignedValidatorRegistration;
 use ethereum_consensus::{
     crypto::SecretKey,
@@ -11,6 +8,10 @@ use ethereum_consensus::{
     state_transition::{Context, Error},
 };
 use ssz_rs::prelude::*;
+
+use crate::signing::{
+    sign_builder_message, verify_signed_builder_message, verify_signed_consensus_message,
+};
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/mev-rs/src/validator_registry.rs
+++ b/mev-rs/src/validator_registry.rs
@@ -1,4 +1,5 @@
-use crate::{signing::verify_signed_builder_message, types::SignedValidatorRegistration};
+use std::{cmp::Ordering, collections::HashMap};
+
 use beacon_api_client::{Client, Error as ApiError, StateId, ValidatorStatus, ValidatorSummary};
 use ethereum_consensus::{
     builder::ValidatorRegistration,
@@ -6,8 +7,9 @@ use ethereum_consensus::{
     state_transition::{Context, Error as ConsensusError},
 };
 use parking_lot::Mutex;
-use std::{cmp::Ordering, collections::HashMap};
 use thiserror::Error;
+
+use crate::{signing::verify_signed_builder_message, types::SignedValidatorRegistration};
 
 #[derive(Debug, Error)]
 pub enum Error {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,6 @@
 reorder_imports = true
 imports_granularity = "Crate"
+group_imports = "One"
 use_small_heuristics = "Max"
 comment_width = 100
 wrap_comments = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,6 @@
 reorder_imports = true
 imports_granularity = "Crate"
-group_imports = "One"
+group_imports = "StdExternalCrate"
 use_small_heuristics = "Max"
 comment_width = 100
 wrap_comments = true


### PR DESCRIPTION
given some back and forth on #96 w.r.t. imports, we can add [`group_imports`](https://rust-lang.github.io/rustfmt/?version=v1.5.1&search=#group_imports) to `rustfmt.toml`.