### PR TITLE
improve logging in mev-boost-rs

### DIFF
--- a/mev-boost-rs/src/relay_mux.rs
+++ b/mev-boost-rs/src/relay_mux.rs
@@ -20,7 +20,7 @@ use std::{collections::HashMap, ops::Deref, sync::Arc, time::Duration};
 // TODO likely drop this feature...
 const PROPOSAL_TOLERANCE_DELAY: Slot = 1;
 // Give relays this amount of time in seconds to return bids.
-const FETCH_BEST_BID_TIME_OUT: u64 = 1;
+const FETCH_BEST_BID_TIME_OUT_SECS: u64 = 1;
 
 fn validate_bid(
     bid: &mut SignedBuilderBid,
@@ -97,14 +97,23 @@ impl BlindedBlockProvider for RelayMux {
     ) -> Result<(), Error> {
         let registrations = &registrations;
         let responses = stream::iter(self.relays.iter().cloned())
-            .map(|relay| async move { relay.register_validators(registrations).await })
+            .map(|relay| async move {
+                let response = relay.register_validators(registrations).await;
+                (relay.public_key, response)
+            })
             .buffer_unordered(self.relays.len())
             .collect::<Vec<_>>()
             .await;
 
-        let failures = responses.iter().filter(|r| r.is_err());
+        let mut num_failures = 0;
+        for (relay, response) in responses {
+            if let Err(err) = response {
+                num_failures += 1;
+                tracing::warn!("failed to register with relay {relay}: {err}");
+            }
+        }
 
-        if failures.count() == self.relays.len() {
+        if num_failures == self.relays.len() {
             Err(Error::CouldNotRegister)
         } else {
             Ok(())
@@ -113,44 +122,35 @@ impl BlindedBlockProvider for RelayMux {
 
     async fn fetch_best_bid(&self, bid_request: &BidRequest) -> Result<SignedBuilderBid, Error> {
         let responses = stream::iter(self.relays.iter().cloned())
-            .map(|relay| async move {
-                tokio::time::timeout(
-                    Duration::from_secs(FETCH_BEST_BID_TIME_OUT),
+            .enumerate()
+            .map(|(index, relay)| async move {
+                let response = tokio::time::timeout(
+                    Duration::from_secs(FETCH_BEST_BID_TIME_OUT_SECS),
                     relay.fetch_best_bid(bid_request),
                 )
-                .await
+                .await;
+                (index, response)
             })
             .buffer_unordered(self.relays.len())
             .collect::<Vec<_>>()
             .await;
 
-        // ideally can fuse the filtering into the prior async fetch but
-        // several attempts lead to opaque compiler errors...
-        let bids = responses
-        .into_iter()
-        .enumerate()
-        .filter_map(|(relay_index, response)| match response {
-            Ok(Ok(mut bid)) => {
-                let public_key = &self.relays[relay_index].public_key;
-                if let Err(err) = validate_bid(&mut bid, public_key, &self.context) {
-                    tracing::warn!("invalid signed builder bid: {err} for bid: {bid:?}");
-                    None
-                } else {
-                    Some((bid, relay_index))
+        let mut bids = Vec::with_capacity(responses.len());
+        for (relay_index, response) in responses {
+            let relay_public_key = &self.relays[relay_index].public_key;
+
+            match response {
+                Ok(Ok(mut bid)) => {
+                    if let Err(err) = validate_bid(&mut bid, relay_public_key, &self.context) {
+                        tracing::warn!("invalid signed builder bid from relay {relay_public_key}: {err}");
+                    } else {
+                        bids.push((bid, relay_index));
+                    }
                 }
+                Ok(Err(err)) => tracing::warn!("failed to get a bid from relay {relay_public_key}: {err}"),
+                Err(..) => tracing::warn!("failed to get bid from relay {relay_public_key} within {FETCH_BEST_BID_TIME_OUT_SECS}s timeout"),
             }
-            Ok(Err(err)) => {
-                tracing::warn!("failed to get a bid from relay {relay_index}: {err}");
-                None
-            }
-            Err(_) => {
-                tracing::warn!(
-                    "relay {relay_index} didn't provide bid before time out {FETCH_BEST_BID_TIME_OUT}s."
-                );
-                None
-            }
-        })
-        .collect::<Vec<_>>();
+        }
 
         let mut best_indices = select_best_bids(bids.iter().map(|(bid, i)| (bid.value(), *i)));
 
@@ -196,24 +196,27 @@ impl BlindedBlockProvider for RelayMux {
         let signed_block = &signed_block;
         let relays = relay_indices.into_iter().map(|i| self.relays[i].clone());
         let responses = stream::iter(relays)
-            .map(|relay| async move { relay.open_bid(signed_block).await })
+            .map(|relay| async move {
+                let response = relay.open_bid(signed_block).await;
+                (relay.public_key, response)
+            })
             .buffer_unordered(self.relays.len())
             .collect::<Vec<_>>()
             .await;
 
         let expected_block_hash = signed_block.block_hash();
-        for (i, response) in responses.into_iter().enumerate() {
+        for (relay, response) in responses.into_iter() {
             match response {
                 Ok(payload) => {
                     let block_hash = payload.block_hash();
                     if block_hash == expected_block_hash {
                         return Ok(payload)
                     } else {
-                        tracing::warn!("error opening bid from relay {i}: the returned payload with block hash {block_hash} did not match the expected block hash: {expected_block_hash}");
+                        tracing::warn!("error opening bid from relay {relay}: the returned payload with block hash {block_hash} did not match the expected block hash: {expected_block_hash}");
                     }
                 }
                 Err(err) => {
-                    tracing::warn!("error opening bid from relay {i}: {err}");
+                    tracing::warn!("error opening bid from relay {relay}: {err}");
                 }
             }
         }


### PR DESCRIPTION
add the following tracing events:

* (WARN) failed registration with a given relay

in various other tracing events, log the relay public key instead of the relay index.

refactor/fix: currently, the pending response futures are put into a buffered list with the [`buffer_unordered`](https://docs.rs/futures/0.3.28/futures/stream/trait.StreamExt.html#method.buffer_unordered) adaptor. this adaptor will yield the futures in the order in which they complete, which may be inconsistent with the order in which they were initially created. however, subsequent logic appears to rely on a consistent ordering. changes were included to group the relay index (or public key) with the response at the time the request was made.