### PR TITLE
Add `enable_cancellation` flag to `submit_bid()` of blinded_block_relay

### DIFF
--- a/mev-rs/src/blinded_block_relayer/api/client.rs
+++ b/mev-rs/src/blinded_block_relayer/api/client.rs
@@ -27,7 +27,7 @@ impl BlindedBlockRelayer for Client {
     async fn submit_bid(
         &self,
         signed_submission: &SignedBidSubmission,
-        with_cancellation: bool,
+        with_cancellations: bool,
     ) -> Result<SignedBidReceipt, Error> {
         let response = self.api.http_post("/relay/v1/builder/blocks", signed_submission).await?;
         let receipt: ApiResult<SignedBidReceipt> = response.json().await.map_err(ApiError::from)?;

--- a/mev-rs/src/blinded_block_relayer/api/client.rs
+++ b/mev-rs/src/blinded_block_relayer/api/client.rs
@@ -27,6 +27,7 @@ impl BlindedBlockRelayer for Client {
     async fn submit_bid(
         &self,
         signed_submission: &SignedBidSubmission,
+        cancellation_enabled: bool,
     ) -> Result<SignedBidReceipt, Error> {
         let response = self.api.http_post("/relay/v1/builder/blocks", signed_submission).await?;
         let receipt: ApiResult<SignedBidReceipt> = response.json().await.map_err(ApiError::from)?;

--- a/mev-rs/src/blinded_block_relayer/api/client.rs
+++ b/mev-rs/src/blinded_block_relayer/api/client.rs
@@ -27,7 +27,7 @@ impl BlindedBlockRelayer for Client {
     async fn submit_bid(
         &self,
         signed_submission: &SignedBidSubmission,
-        cancellation_enabled: bool,
+        with_cancellation: bool,
     ) -> Result<SignedBidReceipt, Error> {
         let response = self.api.http_post("/relay/v1/builder/blocks", signed_submission).await?;
         let receipt: ApiResult<SignedBidReceipt> = response.json().await.map_err(ApiError::from)?;

--- a/mev-rs/src/blinded_block_relayer/api/server.rs
+++ b/mev-rs/src/blinded_block_relayer/api/server.rs
@@ -4,7 +4,7 @@ use crate::{
     types::{ProposerSchedule, SignedBidReceipt, SignedBidSubmission},
 };
 use axum::{
-    extract::{Json, State},
+    extract::{Json, Query, State},
     routing::{get, post, IntoMakeService},
     Router,
 };
@@ -24,10 +24,11 @@ async fn handle_get_proposal_schedule<R: BlindedBlockRelayer>(
 
 async fn handle_submit_bid<R: BlindedBlockRelayer>(
     State(relayer): State<R>,
+    Query(enable_cancellation): Query<bool>,
     Json(signed_bid_submission): Json<SignedBidSubmission>,
 ) -> Result<Json<SignedBidReceipt>, Error> {
     tracing::info!("handling bid submission");
-    Ok(Json(relayer.submit_bid(&signed_bid_submission).await?))
+    Ok(Json(relayer.submit_bid(&signed_bid_submission, enable_cancellation).await?))
 }
 
 pub struct Server<R: BlindedBlockRelayer> {

--- a/mev-rs/src/blinded_block_relayer/api/server.rs
+++ b/mev-rs/src/blinded_block_relayer/api/server.rs
@@ -24,11 +24,11 @@ async fn handle_get_proposal_schedule<R: BlindedBlockRelayer>(
 
 async fn handle_submit_bid<R: BlindedBlockRelayer>(
     State(relayer): State<R>,
-    Query(enable_cancellation): Query<bool>,
+    Query(with_cancellation): Query<bool>,
     Json(signed_bid_submission): Json<SignedBidSubmission>,
 ) -> Result<Json<SignedBidReceipt>, Error> {
     tracing::info!("handling bid submission");
-    Ok(Json(relayer.submit_bid(&signed_bid_submission, enable_cancellation).await?))
+    Ok(Json(relayer.submit_bid(&signed_bid_submission, with_cancellation).await?))
 }
 
 pub struct Server<R: BlindedBlockRelayer> {

--- a/mev-rs/src/blinded_block_relayer/api/server.rs
+++ b/mev-rs/src/blinded_block_relayer/api/server.rs
@@ -24,11 +24,11 @@ async fn handle_get_proposal_schedule<R: BlindedBlockRelayer>(
 
 async fn handle_submit_bid<R: BlindedBlockRelayer>(
     State(relayer): State<R>,
-    Query(with_cancellation): Query<bool>,
+    Query(with_cancellations): Query<bool>,
     Json(signed_bid_submission): Json<SignedBidSubmission>,
 ) -> Result<Json<SignedBidReceipt>, Error> {
     tracing::info!("handling bid submission");
-    Ok(Json(relayer.submit_bid(&signed_bid_submission, with_cancellation).await?))
+    Ok(Json(relayer.submit_bid(&signed_bid_submission, with_cancellations).await?))
 }
 
 pub struct Server<R: BlindedBlockRelayer> {

--- a/mev-rs/src/blinded_block_relayer/mod.rs
+++ b/mev-rs/src/blinded_block_relayer/mod.rs
@@ -18,5 +18,6 @@ pub trait BlindedBlockRelayer {
     async fn submit_bid(
         &self,
         signed_submission: &SignedBidSubmission,
+        enable_cancellations: bool,
     ) -> Result<SignedBidReceipt, Error>;
 }

--- a/mev-rs/src/blinded_block_relayer/mod.rs
+++ b/mev-rs/src/blinded_block_relayer/mod.rs
@@ -18,6 +18,6 @@ pub trait BlindedBlockRelayer {
     async fn submit_bid(
         &self,
         signed_submission: &SignedBidSubmission,
-        enable_cancellations: bool,
+        with_cancellations: bool,
     ) -> Result<SignedBidReceipt, Error>;
 }


### PR DESCRIPTION
Adds cancellation parameter to `submit_bid()` trait method and adds a `Query()` extractor to the server handler to deserialize the query parameter.

Closes #114 