### PR TITLE
refactor: handle missing proposer in bid opening

### DIFF
--- a/mev-build-rs/src/mempool_builder.rs
+++ b/mev-build-rs/src/mempool_builder.rs
@@ -256,7 +256,8 @@ impl BlindedBlockProvider for Builder {
         signed_block: &mut SignedBlindedBeaconBlock,
     ) -> Result<ExecutionPayload, Error> {
         let slot = signed_block.slot();
-        let public_key = self.proposer_scheduler.get_proposer_for(slot)?;
+        let public_key =
+            self.proposer_scheduler.get_proposer_for(slot).ok_or(Error::MissingProposer(slot))?;
         signed_block.verify_signature(&public_key, self.genesis_validators_root, &self.context)?;
 
         let parent_hash = signed_block.parent_hash();

--- a/mev-rs/src/error.rs
+++ b/mev-rs/src/error.rs
@@ -1,7 +1,7 @@
 use crate::types::BidRequest;
 use beacon_api_client::Error as ApiError;
 use ethereum_consensus::{
-    primitives::{BlsPublicKey, ExecutionAddress, Hash32},
+    primitives::{BlsPublicKey, ExecutionAddress, Hash32, Slot},
     state_transition::Error as ConsensusError,
 };
 use thiserror::Error;
@@ -16,6 +16,8 @@ pub enum Error {
     NoBids,
     #[error("could not find relay with outstanding bid to accept")]
     MissingOpenBid,
+    #[error("could not find proposer for slot {0}")]
+    MissingProposer(Slot),
     #[error("could not register with any relay")]
     CouldNotRegister,
     #[error("no preferences found for validator with public key {0}")]

--- a/mev-rs/src/proposer_scheduler.rs
+++ b/mev-rs/src/proposer_scheduler.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("could find a proposer for the requested slot {0}")]
+    #[error("missing proposer for the requested slot {0}")]
     MissingProposer(Slot),
     #[error("api error: {0}")]
     Api(#[from] ApiError),

--- a/mev-rs/src/proposer_scheduler.rs
+++ b/mev-rs/src/proposer_scheduler.rs
@@ -8,8 +8,6 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("missing proposer for the requested slot {0}")]
-    MissingProposer(Slot),
     #[error("api error: {0}")]
     Api(#[from] ApiError),
 }
@@ -48,8 +46,8 @@ impl ProposerScheduler {
         Ok(duties)
     }
 
-    pub fn get_proposer_for(&self, slot: Slot) -> Result<BlsPublicKey, Error> {
+    pub fn get_proposer_for(&self, slot: Slot) -> Option<BlsPublicKey> {
         let state = self.state.lock();
-        state.proposer_schedule.get(&slot).cloned().ok_or_else(|| Error::MissingProposer(slot))
+        state.proposer_schedule.get(&slot).cloned()
     }
 }


### PR DESCRIPTION
return `Option` instead of `Result` in `ProposerScheduler::get_proposer_for`