### PR TITLE
feat(mev-relay): Relay Verification

### DIFF
--- a/mev-rs/src/error.rs
+++ b/mev-rs/src/error.rs
@@ -30,8 +30,16 @@ pub enum Error {
     InvalidFork,
     #[error("block does not match the provided header")]
     UnknownBlock,
+    #[error("signed block does not match the provided local payload")]
+    UnknownSignedBlock,
+    #[error("signed block slot lies outside accepted time window")]
+    UntimelyBlock,
     #[error("payload request does not match any outstanding bid")]
     UnknownBid,
+    #[error("bid public key does not match a registered proposer")]
+    UnknownBidProposer,
+    #[error("bids slot lies outside accepted time window")]
+    UntimelyBid,
     #[error("validator {0} does not have {1} fee recipient")]
     UnknownFeeRecipient(BlsPublicKey, ExecutionAddress),
     #[error("validator with public key {0} is not currently registered")]

--- a/mev-rs/src/types/mod.rs
+++ b/mev-rs/src/types/mod.rs
@@ -305,6 +305,22 @@ impl ExecutionPayload {
             Self::Deneb(payload_and_blobs) => payload_and_blobs.execution_payload.gas_limit,
         }
     }
+
+    pub fn parent_hash(&self) -> &Hash32 {
+        match self {
+            Self::Bellatrix(payload) => &payload.parent_hash,
+            Self::Capella(payload) => &payload.parent_hash,
+            Self::Deneb(payload_and_blobs) => &payload_and_blobs.execution_payload.parent_hash,
+        }
+    }
+
+    pub fn fee_recipient(&self) -> &ExecutionAddress {
+        match self {
+            Self::Bellatrix(payload) => &payload.fee_recipient,
+            Self::Capella(payload) => &payload.fee_recipient,
+            Self::Deneb(payload_and_blobs) => &payload_and_blobs.execution_payload.fee_recipient,
+        }
+    }
 }
 
 impl TryFrom<&mut ExecutionPayload> for ExecutionPayloadHeader {


### PR DESCRIPTION
Adds relay verifications excluding the following:

- Execution Payload verification (requiring EL client block simulation)
- Bid Chaintip verification (requires a beacon node header events streaming service as implemented in  [mev-boost](https://github.com/flashbots/mev-boost-relay/blob/main/beaconclient/prod_beacon_instance.go#L73))

Happy to chase adding the header event service but wanted to hold off until the full roadmap is put together #129.

Refs: #113 and #93 