### PR TITLE
Update boost logging

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
           mev = pkgs.callPackage ./nix/mev.nix { inherit pkgs; crane = craneLib; };
         in
         {
-          devShells.default = import ./shell.nix { inherit pkgs rustToolchain; };
+          devShells.default = import ./shell.nix { inherit pkgs; };
           overlays.default = _: _: {
             inherit mev;
           };

--- a/mev-rs/src/relay.rs
+++ b/mev-rs/src/relay.rs
@@ -12,7 +12,7 @@ use ethereum_consensus::{
 use std::{fmt, ops::Deref};
 use url::Url;
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct RelayEndpoint {
     url: Url,
     public_key: BlsPublicKey,
@@ -26,6 +26,12 @@ impl TryFrom<Url> for RelayEndpoint {
         let public_key = BlsPublicKey::try_from(&public_key[..])?;
 
         Ok(Self { url, public_key })
+    }
+}
+
+impl fmt::Debug for RelayEndpoint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "{0}", self.url)
     }
 }
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,13 @@
-{ pkgs, rustToolchain }:
+{ pkgs }:
 with pkgs;
 mkShell {
-  buildInputs = [
+  buildInputs = lib.optionals pkgs.stdenv.isLinux [
+    openssl
+  ] ++ lib.optionals pkgs.stdenv.isDarwin [
+    libiconv
+    darwin.apple_sdk.frameworks.Network
+  ] ++ [
     just
     mdbook
-    rustToolchain
   ];
 }


### PR DESCRIPTION
1. fixes issue w/ deps in local nix shell
2. moves (all) logging IO to "spawn" for `mev-boost-rs`
3. logs all relays configured for boost operation