### PR TITLE
Update path to install mev-rs

### DIFF
--- a/book/mev-build-rs.md
+++ b/book/mev-build-rs.md
@@ -23,7 +23,7 @@ You can install the `mev-rs` binary, named `mev`, with the following steps:
 ```sh
 git clone https://github.com/ralexstokes/mev-rs
 cd mev-rs
-cargo install --locked
+cargo install --locked --path bin/mev 
 ```
 
 > The builder has been verified as of this commit `bf3d41f026e9728233dd3e1c40e75c49b9ae00b3`. No guarantees about other states of the repository currently.


### PR DESCRIPTION
When installing with the current command (cargo install --locked) in the root folder, it throws the following error:  "found a virtual manifest at `/Users/.../Cargo.toml` instead of a package manifest" 

So we need to specify the path of the binary.