### PR TITLE
add exponential backoff retries if the beacon node event stream is down

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,6 +680,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.10",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
 name = "backon"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4444,6 +4458,7 @@ name = "mev-relay-rs"
 version = "0.3.0"
 dependencies = [
  "async-trait",
+ "backoff",
  "beacon-api-client",
  "ethereum-consensus",
  "futures",

--- a/mev-relay-rs/Cargo.toml
+++ b/mev-relay-rs/Cargo.toml
@@ -13,6 +13,7 @@ futures = "0.3.21"
 async-trait = "0.1.53"
 parking_lot = "0.12.1"
 pin-project = "1.0.12"
+backoff = { version = "0.4.0", features = ["tokio"] }
 
 thiserror = "1.0.30"
 http = "0.2.7"

--- a/mev-relay-rs/src/relay.rs
+++ b/mev-relay-rs/src/relay.rs
@@ -296,6 +296,7 @@ impl Relay {
 
     // TODO: build tip context and support reorgs...
     pub fn on_payload_attributes(&self, event: PayloadAttributesEvent) -> Result<(), Error> {
+        trace!(?event, "processing payload attributes");
         let proposer_public_key =
             self.validator_registry.get_public_key(event.proposer_index).ok_or_else::<Error, _>(
                 || RelayError::UnknownValidatorIndex(event.proposer_index).into(),


### PR DESCRIPTION
the current code will cancel the entire relay service if the events stream goes down (e.g. restarting a local CL while testing)

we don't expect this to be much of an issue in more realistic settings but we can avoid the problem entirely with this set of fixes to retry the event stream