### PR TITLE
update to latest ssz with transparent derive and alloy types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,7 +753,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon-api-client"
 version = "0.1.0"
-source = "git+https://github.com/ralexstokes/ethereum-consensus?rev=6338befe3db58b74a40376ebd4330843e3c3844a#6338befe3db58b74a40376ebd4330843e3c3844a"
+source = "git+https://github.com/ralexstokes/ethereum-consensus?rev=b9baee3f3b9fc76bd9b5bc22b78edc05446af815#b9baee3f3b9fc76bd9b5bc22b78edc05446af815"
 dependencies = [
  "clap",
  "ethereum-consensus",
@@ -1191,6 +1191,21 @@ name = "c-kzg"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac926d808fb72fe09ebf471a091d6d72918876ccf0b4989766093d2d0d24a0ef"
+dependencies = [
+ "bindgen 0.66.1",
+ "blst",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
+ "serde",
+]
+
+[[package]]
+name = "c-kzg"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32700dc7904064bb64e857d38a1766607372928e2466ee5f02a869829b3297d7"
 dependencies = [
  "bindgen 0.66.1",
  "blst",
@@ -2426,12 +2441,12 @@ dependencies = [
 [[package]]
 name = "ethereum-consensus"
 version = "0.1.1"
-source = "git+https://github.com/ralexstokes/ethereum-consensus?rev=6338befe3db58b74a40376ebd4330843e3c3844a#6338befe3db58b74a40376ebd4330843e3c3844a"
+source = "git+https://github.com/ralexstokes/ethereum-consensus?rev=b9baee3f3b9fc76bd9b5bc22b78edc05446af815#b9baee3f3b9fc76bd9b5bc22b78edc05446af815"
 dependencies = [
  "async-stream",
  "blst",
  "bs58 0.4.0",
- "c-kzg",
+ "c-kzg 0.4.0",
  "enr 0.6.2",
  "hex",
  "integer-sqrt",
@@ -6384,7 +6399,7 @@ dependencies = [
  "arbitrary",
  "byteorder",
  "bytes",
- "c-kzg",
+ "c-kzg 0.1.1",
  "clap",
  "crc",
  "derive_more",
@@ -6780,7 +6795,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d360a88223d85709d2e95d4609eb1e19c649c47e28954bfabae5e92bb37e83e"
 dependencies = [
- "c-kzg",
+ "c-kzg 0.1.1",
  "k256 0.13.1",
  "num",
  "once_cell",
@@ -6801,7 +6816,7 @@ dependencies = [
  "auto_impl",
  "bitflags 2.4.1",
  "bitvec",
- "c-kzg",
+ "c-kzg 0.1.1",
  "enumn",
  "hashbrown 0.14.2",
  "hex",
@@ -7683,11 +7698,11 @@ checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 [[package]]
 name = "ssz_rs"
 version = "0.9.0"
-source = "git+https://github.com/ralexstokes/ssz-rs?rev=6755022b7727e3392bfbc2b9c683cb7bf9caa4ce#6755022b7727e3392bfbc2b9c683cb7bf9caa4ce"
+source = "git+https://github.com/ralexstokes/ssz-rs?rev=db3bca54b23522df224b1d7d4ac3c3b805a49e84#db3bca54b23522df224b1d7d4ac3c3b805a49e84"
 dependencies = [
+ "alloy-primitives",
  "bitvec",
  "hex",
- "num-bigint",
  "serde",
  "sha2 0.9.9",
  "ssz_rs_derive",
@@ -7696,7 +7711,7 @@ dependencies = [
 [[package]]
 name = "ssz_rs_derive"
 version = "0.9.0"
-source = "git+https://github.com/ralexstokes/ssz-rs?rev=6755022b7727e3392bfbc2b9c683cb7bf9caa4ce#6755022b7727e3392bfbc2b9c683cb7bf9caa4ce"
+source = "git+https://github.com/ralexstokes/ssz-rs?rev=db3bca54b23522df224b1d7d4ac3c3b805a49e84#db3bca54b23522df224b1d7d4ac3c3b805a49e84"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ default-members = ["bin/mev"]
 version = "0.3.0"
 
 [workspace.dependencies]
-ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "6338befe3db58b74a40376ebd4330843e3c3844a" }
-beacon-api-client = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "6338befe3db58b74a40376ebd4330843e3c3844a" }
+ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "b9baee3f3b9fc76bd9b5bc22b78edc05446af815" }
+beacon-api-client = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "b9baee3f3b9fc76bd9b5bc22b78edc05446af815" }
 
 reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5dd5555c5c7d8e43420e273e7005b8af63a847a5" }
 reth-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5dd5555c5c7d8e43420e273e7005b8af63a847a5" }

--- a/mev-boost-rs/src/relay_mux.rs
+++ b/mev-boost-rs/src/relay_mux.rs
@@ -53,7 +53,7 @@ fn validate_bid(
 // Select the most valuable bids in `bids`, breaking ties by `block_hash`
 fn select_best_bids(bids: impl Iterator<Item = (usize, U256)>) -> Vec<usize> {
     let (best_indices, _value) =
-        bids.fold((vec![], U256::zero()), |(mut best_indices, max), (index, value)| {
+        bids.fold((vec![], U256::ZERO), |(mut best_indices, max), (index, value)| {
             match value.cmp(&max) {
                 Ordering::Greater => (vec![index], value),
                 Ordering::Equal => {
@@ -200,7 +200,7 @@ impl BlindedBlockProvider for RelayMux {
 
         // TODO: change `value` so it does the copy internally
         let mut best_bid_indices =
-            select_best_bids(bids.iter().map(|(_, bid)| bid.message.value.clone()).enumerate());
+            select_best_bids(bids.iter().map(|(_, bid)| bid.message.value).enumerate());
 
         // if multiple distinct bids with same bid value, break tie by randomly picking one
         let mut rng = rand::thread_rng();

--- a/mev-build-rs/src/reth_builder/reth_compat.rs
+++ b/mev-build-rs/src/reth_builder/reth_compat.rs
@@ -22,7 +22,7 @@ fn to_byte_vector(value: Bloom) -> ByteVector<256> {
 }
 
 pub(crate) fn to_u256(value: &U256) -> ssz_rs::U256 {
-    ssz_rs::U256::try_from_bytes_le(&value.to_le_bytes::<32>()).unwrap()
+    *value
 }
 
 pub(crate) fn to_execution_payload(value: &SealedBlock) -> ExecutionPayload {

--- a/mev-relay-rs/src/relay.rs
+++ b/mev-relay-rs/src/relay.rs
@@ -416,8 +416,7 @@ impl Relay {
             }
         }
         let header = to_header(&mut execution_payload)?;
-        let mut bid =
-            BuilderBid { header, value: value.clone(), public_key: self.public_key.clone() };
+        let mut bid = BuilderBid { header, value, public_key: self.public_key.clone() };
         let signature = sign_builder_message(&mut bid, &self.secret_key, &self.context)?;
         let signed_builder_bid = SignedBuilderBid { message: bid, signature };
 
@@ -572,7 +571,7 @@ impl BlindedBlockRelayer for Relay {
                 &signed_submission.execution_payload,
             )?;
             debug!(%auction_request, "validated builder submission");
-            (auction_request, bid_trace.value.clone(), bid_trace.builder_public_key.clone())
+            (auction_request, bid_trace.value, bid_trace.builder_public_key.clone())
         };
 
         signed_submission.verify_signature(&self.context)?;

--- a/mev-rs/src/types/block_submission.rs
+++ b/mev-rs/src/types/block_submission.rs
@@ -28,7 +28,7 @@ pub struct BidTrace {
     pub value: U256,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, SimpleSerialize)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SignedBidSubmission {
     pub message: BidTrace,

--- a/mev-rs/src/types/builder_bid.rs
+++ b/mev-rs/src/types/builder_bid.rs
@@ -10,7 +10,7 @@ use ethereum_consensus::{
 };
 use std::fmt;
 
-#[derive(Debug, Clone, Merkleized)]
+#[derive(Debug, Clone, SimpleSerialize)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BuilderBid {
     pub header: ExecutionPayloadHeader,
@@ -30,7 +30,7 @@ impl BuilderBid {
     }
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, SimpleSerialize, serde::Serialize, serde::Deserialize)]
 pub struct SignedBuilderBid {
     pub message: BuilderBid,
     pub signature: BlsSignature,


### PR DESCRIPTION
- update to latest ssz-rs with "transparent" ssz derive and alloy types
- impl SimpleSerialize for relay types