### PR TITLE
feat(benches): Choose v Shuffle with Benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1239,6 +1245,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1276,6 +1288,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -1560,6 +1599,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -3143,6 +3218,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4394,6 +4475,7 @@ version = "0.3.0"
 dependencies = [
  "async-trait",
  "beacon-api-client",
+ "criterion",
  "ethereum-consensus",
  "futures",
  "mev-build-rs",
@@ -4840,6 +4922,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5264,6 +5352,34 @@ name = "platforms"
 version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4503fa043bf02cee09a9582e9554b4c6403b2ef55e4612e96561d294419429f8"
+
+[[package]]
+name = "plotters"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "pollster"
@@ -8040,6 +8156,16 @@ dependencies = [
  "displaydoc",
  "serde",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/mev-boost-rs/Cargo.toml
+++ b/mev-boost-rs/Cargo.toml
@@ -4,8 +4,6 @@ version.workspace = true
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
@@ -30,3 +28,8 @@ url = { version = "2.2.2", default-features = false }
 serde_json = "1.0.81"
 mev-build-rs = { path = "../mev-build-rs" }
 mev-relay-rs = { path = "../mev-relay-rs" }
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "relay"
+harness = false

--- a/mev-boost-rs/benches/relay.rs
+++ b/mev-boost-rs/benches/relay.rs
@@ -1,0 +1,22 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rand::prelude::SliceRandom;
+
+fn choose(mut v: Vec<usize>) {
+    let mut rng = rand::thread_rng();
+    let i = v.choose(&mut rng).expect("at least one element");
+    v.remove(v.iter().position(|x| x == i).expect("element not found"));
+}
+
+fn shuffle(mut v: Vec<usize>) {
+    let mut rng = rand::thread_rng();
+    v.shuffle(&mut rng);
+    let (_, _) = v.split_first().expect("at least on element");
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("choose", |b| b.iter(|| choose(black_box(vec![2, 5, 3, 5]))));
+    c.bench_function("shuffle", |b| b.iter(|| shuffle(black_box(vec![2, 5, 3, 5]))));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
**Description**

Optimizes `mev-boost-rs` bid selection to use the O(1) [`rand::seq::SliceRandom::choose()`](https://docs.rs/rand/latest/rand/seq/trait.SliceRandom.html#tymethod.choose) over the O(n) [`rand::seq::SliceRandom::shuffle()`](https://docs.rs/rand/latest/rand/seq/trait.SliceRandom.html#tymethod.shuffle).

Benchmark included with improved time shown below.

<img width="515" alt="Screenshot 2023-11-11 at 7 24 49 AM" src="https://github.com/ralexstokes/mev-rs/assets/21288394/148f3b22-ed10-4018-967d-eb58ecd9770c">

