### PR TITLE
chore(bin): Init Subcommand and Refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4384,6 +4384,7 @@ dependencies = [
  "reth",
  "serde",
  "tokio",
+ "toml 0.8.6",
  "tracing",
  "tracing-subscriber",
 ]

--- a/bin/mev/Cargo.toml
+++ b/bin/mev/Cargo.toml
@@ -4,8 +4,6 @@ version.workspace = true
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [features]
 default = ["boost", "build", "relay"]
 boost = ["mev-boost-rs"]
@@ -16,6 +14,7 @@ relay = ["mev-relay-rs"]
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+toml = "0.8.2"
 
 mev-boost-rs = { path = "../../mev-boost-rs", optional = true }
 mev-relay-rs = { path = "../../mev-relay-rs", optional = true }

--- a/bin/mev/src/cmd.rs
+++ b/bin/mev/src/cmd.rs
@@ -1,7 +1,9 @@
+pub mod debug;
+pub mod init;
+
 #[cfg(feature = "boost")]
 pub mod boost;
 #[cfg(feature = "build")]
 pub mod build;
-pub mod config;
 #[cfg(feature = "relay")]
 pub mod relay;

--- a/bin/mev/src/cmd/boost.rs
+++ b/bin/mev/src/cmd/boost.rs
@@ -1,4 +1,4 @@
-use crate::cmd::config::Config;
+use crate::config::Config;
 use clap::Args;
 use mev_boost_rs::Service;
 use tracing::info;

--- a/bin/mev/src/cmd/debug.rs
+++ b/bin/mev/src/cmd/debug.rs
@@ -1,0 +1,21 @@
+use clap::Args;
+
+use crate::config::Config;
+
+#[derive(Debug, Args)]
+#[clap(about = "🔬 (debug) utility to verify configuration")]
+pub struct Command {
+    #[clap(env)]
+    config_file: String,
+}
+
+impl Command {
+    pub async fn execute(self) -> eyre::Result<()> {
+        let config_file = self.config_file;
+
+        let config = Config::from_toml_file(config_file)?;
+        tracing::info!("{config:#?}");
+
+        Ok(())
+    }
+}

--- a/bin/mev/src/cmd/init.rs
+++ b/bin/mev/src/cmd/init.rs
@@ -1,0 +1,34 @@
+use clap::Args;
+
+use crate::config::Config;
+
+/// Include the `example.config.toml` file as a string constant
+/// in the binary. The [`include_str`] macro will read the file
+/// at compile time and include the contents in the binary.
+const EXAMPLE_CONFIG: &str = std::include_str!("../../../../example.config.toml");
+
+#[derive(Debug, Args)]
+#[clap(about = "✨ (init) initializes a new config file")]
+pub struct Command {
+    /// The path to write the config file
+    #[clap(env, default_value = "config.toml")]
+    dest: String,
+}
+
+impl Command {
+    pub fn execute(self) -> eyre::Result<()> {
+        // Deserialize EXAMPLE_CONFIG into a Config struct
+        let config: Config = toml::from_str(EXAMPLE_CONFIG)?;
+        tracing::debug!("Loaded config template.");
+
+        // Serialize the Config struct into a TOML string
+        let contents = toml::to_string_pretty(&config)?;
+        tracing::debug!("Serialized config to TOML.");
+
+        // Write the TOML string to a file
+        std::fs::write(&self.dest, contents)?;
+        tracing::debug!("Wrote config to `{}`.", self.dest);
+
+        Ok(())
+    }
+}

--- a/bin/mev/src/cmd/relay.rs
+++ b/bin/mev/src/cmd/relay.rs
@@ -1,4 +1,4 @@
-use crate::cmd::config::Config;
+use crate::config::Config;
 use clap::{Args, Subcommand};
 use mev_relay_rs::Service;
 use tracing::info;

--- a/bin/mev/src/config.rs
+++ b/bin/mev/src/config.rs
@@ -1,18 +1,17 @@
-use clap::Args;
 use ethereum_consensus::networks::Network;
 use eyre::WrapErr;
+use mev_rs::config::from_toml_file;
+use serde::{Deserialize, Serialize};
+use std::{fmt, path::Path};
+
 #[cfg(feature = "boost")]
 use mev_boost_rs::Config as BoostConfig;
 #[cfg(feature = "build")]
 use mev_build_rs::reth_builder::Config as BuildConfig;
 #[cfg(feature = "relay")]
 use mev_relay_rs::Config as RelayConfig;
-use mev_rs::config::from_toml_file;
-use serde::Deserialize;
-use std::{fmt, path::Path};
-use tracing::info;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Config {
     pub network: Network,
     #[cfg(feature = "boost")]
@@ -29,23 +28,5 @@ impl Config {
         tracing::info!("loading config from `{path}`...");
 
         from_toml_file::<_, Self>(path.as_ref()).wrap_err("could not parse TOML")
-    }
-}
-
-#[derive(Debug, Args)]
-#[clap(about = "🔬 (debug) utility to verify configuration")]
-pub struct Command {
-    #[clap(env)]
-    config_file: String,
-}
-
-impl Command {
-    pub async fn execute(self) -> eyre::Result<()> {
-        let config_file = self.config_file;
-
-        let config = Config::from_toml_file(config_file)?;
-        info!("{config:#?}");
-
-        Ok(())
     }
 }

--- a/bin/mev/src/lib.rs
+++ b/bin/mev/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod cmd;
+pub mod config;

--- a/mev-boost-rs/src/service.rs
+++ b/mev-boost-rs/src/service.rs
@@ -9,12 +9,12 @@ use mev_rs::{
     relay::{parse_relay_endpoints, Relay, RelayEndpoint},
     Error,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::{future::Future, net::Ipv4Addr, pin::Pin, task::Poll};
 use tokio::task::{JoinError, JoinHandle};
 use tracing::{error, info};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Config {
     pub host: Ipv4Addr,
     pub port: u16,

--- a/mev-build-rs/src/reth_builder/service.rs
+++ b/mev-build-rs/src/reth_builder/service.rs
@@ -12,15 +12,23 @@ use ethers::signers::{coins_bip39::English, MnemonicBuilder, Signer};
 use futures::StreamExt;
 use mev_rs::{relay::parse_relay_endpoints, Error, Relay};
 use reth_primitives::{Bytes, ChainSpec};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize, Serializer};
 use std::{future::Future, pin::Pin, sync::Arc, task::Poll};
 use tokio::task::{JoinError, JoinHandle};
 use tracing::{error, info};
 
 const DEFAULT_BID_PERCENT: f64 = 0.9;
 
-#[derive(Deserialize, Debug, Default, Clone)]
+fn serialize_secret_key<S>(x: &SecretKey, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    s.serialize_str(format!("{:?}", x).as_str())
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct Config {
+    #[serde(serialize_with = "serialize_secret_key")]
     pub secret_key: SecretKey,
     pub relays: Vec<String>,
     pub extra_data: Bytes,

--- a/mev-build-rs/src/reth_builder/service_ext.rs
+++ b/mev-build-rs/src/reth_builder/service_ext.rs
@@ -26,7 +26,7 @@ pub struct ServiceExt {
 }
 
 // NOTE: this is duplicated here to avoid circular import b/t `mev` bin and `mev-rs` crate
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct Config {
     pub network: Network,
     #[serde(rename = "builder")]

--- a/mev-relay-rs/src/service.rs
+++ b/mev-relay-rs/src/service.rs
@@ -9,17 +9,25 @@ use ethereum_consensus::{
 };
 use futures::StreamExt;
 use mev_rs::{blinded_block_relayer::Server as BlindedBlockRelayerServer, Error};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize, Serializer};
 use std::{future::Future, net::Ipv4Addr, pin::Pin, task::Poll};
 use tokio::task::{JoinError, JoinHandle};
 use tracing::{error, warn};
 use url::Url;
 
-#[derive(Deserialize, Debug)]
+fn serialize_secret_key<S>(x: &SecretKey, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    s.serialize_str(format!("{:?}", x).as_str())
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Config {
     pub host: Ipv4Addr,
     pub port: u16,
     pub beacon_node_url: String,
+    #[serde(serialize_with = "serialize_secret_key")]
     pub secret_key: SecretKey,
     pub accepted_builders: Vec<BlsPublicKey>,
 }


### PR DESCRIPTION
**Description**

Introduces an `mev init` subcommand to write the `example.config.toml` file to a destination (`config.toml` by default).