### PR TITLE
feat(mev-rs): Relay Test Utils

### DIFF
--- a/mev-relay-rs/Cargo.toml
+++ b/mev-relay-rs/Cargo.toml
@@ -4,8 +4,6 @@ version.workspace = true
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"

--- a/mev-rs/Cargo.toml
+++ b/mev-rs/Cargo.toml
@@ -4,13 +4,12 @@ version.workspace = true
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [features]
 default = ["serde", "builder-api", "relay-api"]
 builder-api = ["api"]
 relay-api = ["api", "builder-api"]
 api = ["tokio", "axum", "hyper", "beacon-api-client", "tracing", "serde_json"]
+test-utils = ["serde"]
 
 [dependencies]
 tokio = { version = "1.0", optional = true }

--- a/mev-rs/src/lib.rs
+++ b/mev-rs/src/lib.rs
@@ -11,6 +11,9 @@ pub mod signing;
 pub mod types;
 mod validator_registry;
 
+#[cfg(feature = "test-utils")]
+pub mod test_utils;
+
 pub use blinded_block_provider::BlindedBlockProvider;
 pub use blinded_block_relayer::BlindedBlockRelayer;
 

--- a/mev-rs/src/relay.rs
+++ b/mev-rs/src/relay.rs
@@ -56,8 +56,8 @@ pub fn parse_relay_endpoints(relay_urls: &[String]) -> Vec<RelayEndpoint> {
 
 #[derive(Clone)]
 pub struct Relay {
-    provider: BlockProvider,
-    relayer: Relayer,
+    pub(crate) provider: BlockProvider,
+    pub(crate) relayer: Relayer,
     pub public_key: BlsPublicKey,
     pub endpoint: Url,
 }

--- a/mev-rs/src/test_utils.rs
+++ b/mev-rs/src/test_utils.rs
@@ -1,0 +1,73 @@
+use beacon_api_client::mainnet::Client as BeaconApiClient;
+use ethereum_consensus::{primitives::BlsPublicKey, serde::try_bytes_from_hex_str};
+use url::Url;
+
+use crate::{
+    blinded_block_provider::Client as BlindedBlockProvider,
+    blinded_block_relayer::Client as BlindedBlockRelayer, relay::Relay,
+};
+
+/// Mock relay endpoint for testing.
+pub const RELAY_URL: &str = "https://0x845bd072b7cd566f02faeb0a4033ce9399e42839ced64e8b2adcfc859ed1e8e1a5a293336a49feac6d9a5edb779be53a@boost-relay-sepolia.flashbots.net/";
+
+/// Creates a [`BlsPublicKey`] for testing.
+pub fn test_public_key() -> BlsPublicKey {
+    let bytes = try_bytes_from_hex_str("0x845bd072b7cd566f02faeb0a4033ce9399e42839ced64e8b2adcfc859ed1e8e1a5a293336a49feac6d9a5edb779be53a").unwrap();
+    BlsPublicKey::try_from(bytes.as_ref()).unwrap()
+}
+
+/// Creates a mock relay endpoint [`Url`] for testing.
+pub fn test_endpoint() -> Url {
+    Url::parse(RELAY_URL).unwrap()
+}
+
+/// Mock relay for testing
+pub fn test_relay() -> Relay {
+    Relay {
+        provider: test_blinded_block_provider(),
+        relayer: test_blinded_block_relayer(),
+        public_key: test_public_key(),
+        endpoint: test_endpoint(),
+    }
+}
+
+/// Creates a mock [`BeaconApiClient`] for testing.
+pub fn test_beacon_api_client() -> BeaconApiClient {
+    // TODO: we need to intercept requests to stub mock responses
+    BeaconApiClient::new(test_endpoint())
+}
+
+/// Creates a [`BlindedBlockProvider`] for testing.
+pub fn test_blinded_block_provider() -> BlindedBlockProvider {
+    BlindedBlockProvider::new(test_beacon_api_client())
+}
+
+/// Creates a mock [`BlindedBlockRelayer`] for testing.
+pub fn test_blinded_block_relayer() -> BlindedBlockRelayer {
+    BlindedBlockRelayer::new(test_beacon_api_client())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_test_public_key() {
+        let public_key = test_public_key();
+        let bytes = try_bytes_from_hex_str("0x845bd072b7cd566f02faeb0a4033ce9399e42839ced64e8b2adcfc859ed1e8e1a5a293336a49feac6d9a5edb779be53a").unwrap();
+        assert_eq!(public_key, BlsPublicKey::try_from(bytes.as_ref()).unwrap());
+    }
+
+    #[test]
+    fn test_test_endpoint() {
+        let endpoint = test_endpoint();
+        assert_eq!(endpoint.as_str(), RELAY_URL);
+    }
+
+    #[test]
+    fn test_test_relay() {
+        let relay = test_relay();
+        assert_eq!(relay.endpoint.as_str(), RELAY_URL);
+        assert_eq!(relay.public_key, test_public_key());
+    }
+}


### PR DESCRIPTION
**Description**

Introduces a test utilities module in `mev-rs` that sits behind a `test-utils` feature flag. This exposes a helper method to create a mock relay.

Future work will need to provide an abstraction for the internal blinded block provider and relayer such that mock clients can be used in place of the currently used concrete internal components.