### PR TITLE
Log invalid signature.  Propogate generic `RelayError` failure

### DIFF
--- a/mev-relay-rs/src/relay.rs
+++ b/mev-relay-rs/src/relay.rs
@@ -532,7 +532,10 @@ impl BlindedBlockProvider for Relay {
             }
         }
 
-        verify_blinded_block_signature(&auction_request, signed_block, self)?;
+        if let Err(err) = verify_blinded_block_signature(&auction_request, signed_block, self) {
+            warn!(%err, %auction_request, "invalid incoming signed blinded beacon block signature");
+            return Err(RelayError::InvalidSignedBlindedBeaconBlock.into())
+        }
 
         match unblind_block(signed_block, &auction_context.execution_payload) {
             Ok(mut signed_block) => {


### PR DESCRIPTION
Fixes #210 