### PR TITLE
fix: dockerfile -- bump rust version & add build pkgs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.77-bullseye AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-slim-bullseye AS chef
 
 RUN set -x \
     && apt-get -qq update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,15 @@
-FROM rust:1.67-bullseye AS chef
+FROM rust:1.77-bullseye AS chef
+
+RUN set -x \
+    && apt-get -qq update \
+    && apt-get -qq -y install \
+    clang \
+    cmake \
+    libudev-dev \
+    libssl-dev \
+    pkg-config \
+    zlib1g-dev
+
 RUN cargo install cargo-chef
 WORKDIR /app
 


### PR DESCRIPTION
Bump `rust` version, required by `cargo-chef`

<img width="1010" alt="Screenshot 2024-03-30 at 17 36 10" src="https://github.com/ralexstokes/mev-rs/assets/58251349/1a6991ed-4bb6-4902-a715-74238159308e">

Introduced set of build packages for compilation

<img width="1925" alt="Screenshot 2024-03-30 at 18 11 59" src="https://github.com/ralexstokes/mev-rs/assets/58251349/c0b94b93-fa74-481d-b7a8-64f6d4df705a">
