### PR TITLE
Fix nix build issue with `libffi-sys` dep (via `reth` dep)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4494,8 +4494,7 @@ dependencies = [
 [[package]]
 name = "libffi-sys"
 version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36115160c57e8529781b4183c2bb51fdc1f6d6d1ed345591d84be7703befb3c"
+source = "git+https://github.com/tov/libffi-rs?rev=d0704d634b6f3ffef5b6fc7e07fe965a1cff5c7b#d0704d634b6f3ffef5b6fc7e07fe965a1cff5c7b"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ sha2 = "0.10.8"
 
 [patch.crates-io]
 c-kzg = { git = "https://github.com/ethereum/c-kzg-4844", tag = "v1.0.1" }
+libffi-sys = { git = "https://github.com/tov/libffi-rs", rev = "d0704d634b6f3ffef5b6fc7e07fe965a1cff5c7b" }

--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714058985,
-        "narHash": "sha256-gD/Ya/oXic+vbQGvmqxm8qaWmOx3HnrKHQtSL6oRW0E=",
+        "lastModified": 1714314149,
+        "narHash": "sha256-yNAevSKF4krRWacmLUsLK7D7PlfuY3zF0lYnGYNi9vQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bf182c39d9439811484aad0d241ea89619b44bc7",
+        "rev": "cf8cc1201be8bc71b7cbbbdaf349b22f4f99c7ae",
         "type": "github"
       },
       "original": {
@@ -87,11 +87,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714011248,
-        "narHash": "sha256-vKk9IOxZJ52Ao3uIRIjHRYYe+IpVOY6NzwToSxaO1J0=",
+        "lastModified": 1714443211,
+        "narHash": "sha256-lKTA3XqRo4aVgkyTSCtpcALpGXdmkilHTtN00eRg0QU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9a2a11479b94afaf1ecc46384b27abda0d3d5f9d",
+        "rev": "ce35c36f58f82cee6ec959e0d44c587d64281b6f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
`libffi-sys` copies files when building and the release in `reth` uses a version that copies permissions on these files.

In a read-only build env like nix, this would cause a failure to proceed as the files were not writable.

Luckily, this has been fixed in `libffi-sys` and so we can just `patch` the dependency in the cargo manifest.

See links in this commit https://github.com/ralexstokes/mev-rs/pull/223/commits/571b3b8b958086871a43d020682266c388b3c0ff for further info.