### PR TITLE
Builder subsidy from config and refactor `RelaySet`

### DIFF
--- a/example.config.toml
+++ b/example.config.toml
@@ -43,7 +43,7 @@ wait_until_ms = 1000
 # if missing, defaults to 1.0 (100%)
 # validation: should be between [0, 1] inclusive.
 bid_percent = 0.9
-# [optional] amount to add to the bid on top of the payload's revenue,
-# if missing, defaults to 0 wei
+# [optional] amount in wei to add to the bid on top of the payload's revenue,
+# if missing, defaults to `mev_build_rs::payload::builder::DEFAULT_SUBSIDY_PAYMENT`
 # currently sourced from the builder's wallet authoring the payment transaction
-subsidy_wei = "0x0000000000000000000000000000000000000000000000000000000000000001"
+subsidy_wei = "0x000000000000000000000000000000000000000000000000000000174876e800" # 100 Gwei

--- a/example.config.toml
+++ b/example.config.toml
@@ -42,7 +42,7 @@ wait_until_ms = 1000
 # [optional] amount of value to bid as a fraction of the payload's revenue
 # if missing, defaults to 1.0 (100%)
 # validation: should be between [0, 1] inclusive.
-bid_percent = 0.9
+bid_percent = 1.0
 # [optional] amount in wei to add to the bid on top of the payload's revenue,
 # if missing, defaults to `mev_build_rs::payload::builder::DEFAULT_SUBSIDY_PAYMENT`
 # currently sourced from the builder's wallet authoring the payment transaction

--- a/mev-build-rs/src/auctioneer/auction_schedule.rs
+++ b/mev-build-rs/src/auctioneer/auction_schedule.rs
@@ -1,12 +1,10 @@
 use ethereum_consensus::primitives::{BlsPublicKey, Slot};
-use mev_rs::{types::ProposerSchedule, Relay};
+use mev_rs::types::ProposerSchedule;
 use reth::primitives::Address;
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::collections::{HashMap, HashSet};
 
-pub type RelaySet = HashSet<Arc<Relay>>;
+pub type RelayIndex = usize;
+pub type RelaySet = HashSet<RelayIndex>;
 pub type Proposals = HashMap<Proposer, RelaySet>;
 
 #[derive(Debug, Clone, Default, Hash, PartialEq, Eq)]
@@ -30,7 +28,7 @@ impl AuctionSchedule {
         self.schedule.get(&slot)
     }
 
-    pub fn process(&mut self, relay: Arc<Relay>, schedule: &[ProposerSchedule]) -> Vec<Slot> {
+    pub fn process(&mut self, relay: RelayIndex, schedule: &[ProposerSchedule]) -> Vec<Slot> {
         let mut slots = Vec::with_capacity(schedule.len());
         for entry in schedule {
             slots.push(entry.slot);
@@ -42,7 +40,7 @@ impl AuctionSchedule {
                 gas_limit: registration.gas_limit,
             };
             let relays = slot.entry(proposer).or_default();
-            relays.insert(relay.clone());
+            relays.insert(relay);
         }
         slots
     }

--- a/mev-build-rs/src/service.rs
+++ b/mev-build-rs/src/service.rs
@@ -18,7 +18,7 @@ use reth::{
     api::EngineTypes,
     builder::{NodeBuilder, WithLaunchContext},
     payload::{EthBuiltPayload, PayloadBuilderHandle},
-    primitives::{Address, Bytes, NamedChain},
+    primitives::{Address, Bytes, NamedChain, U256},
     tasks::TaskExecutor,
 };
 use reth_db::DatabaseEnv;
@@ -39,6 +39,9 @@ pub struct BuilderConfig {
     pub genesis_time: Option<u64>,
     pub extra_data: Option<Bytes>,
     pub execution_mnemonic: String,
+    // NOTE: This is a temporary field to route the same data from the `BidderConfig`
+    // to the builder. Will be removed once we have communications set up from bidder to builder.
+    pub subsidy_wei: Option<U256>,
 }
 
 #[derive(Deserialize, Debug, Default, Clone)]
@@ -108,8 +111,11 @@ fn custom_network_from_config_directory(path: PathBuf) -> Network {
 pub async fn launch(
     node_builder: WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>>>,
     custom_chain_config_directory: Option<PathBuf>,
-    config: Config,
+    mut config: Config,
 ) -> eyre::Result<()> {
+    // NOTE: temporary shim
+    // TODO: remove once bidder can talk to builder
+    config.builder.subsidy_wei = config.bidder.subsidy_wei;
     let payload_builder = PayloadServiceBuilder::try_from(&config.builder)?;
 
     let handle = node_builder


### PR DESCRIPTION
- use subsidy value from config, instead of hardcoded value, to facilitate easy changing during testing
- and latest nightly clippy raises a lint on using `Arc<Relay>` as a key in `HashSet` -- this repo would not touch this key mutably but there is no way to signal that to the type system, so for now, refactor to working over indices into `Auctioneer::relay` vec