### PR TITLE
loop forever when attempting to read payload attributes

### DIFF
--- a/mev-relay-rs/src/service.rs
+++ b/mev-relay-rs/src/service.rs
@@ -87,39 +87,43 @@ impl Service {
         let consensus = tokio::spawn(async move {
             let relay = relay_clone;
 
-            let result = backoff::future::retry::<(), (), _, _, _>(
-                ExponentialBackoff::default(),
-                || async {
-                    let retry = backoff::Error::transient(());
-                    let mut stream = match beacon_node.get_events::<PayloadAttributesTopic>().await
-                    {
-                        Ok(stream) => stream,
-                        Err(err) => {
-                            error!(%err, "could not open payload attributes stream");
-                            return Err(retry)
-                        }
-                    };
+            loop {
+                let result = backoff::future::retry::<(), (), _, _, _>(
+                    ExponentialBackoff::default(),
+                    || async {
+                        let retry = backoff::Error::transient(());
+                        let mut stream =
+                            match beacon_node.get_events::<PayloadAttributesTopic>().await {
+                                Ok(stream) => stream,
+                                Err(err) => {
+                                    error!(%err, "could not open payload attributes stream");
+                                    return Err(retry)
+                                }
+                            };
 
-                    while let Some(event) = stream.next().await {
-                        match event {
-                            Ok(event) => {
-                                if let Err(err) = relay.on_payload_attributes(event.data) {
-                                    warn!(%err, "could not process payload attributes");
-                                    continue
+                        while let Some(event) = stream.next().await {
+                            match event {
+                                Ok(event) => {
+                                    if let Err(err) = relay.on_payload_attributes(event.data) {
+                                        warn!(%err, "could not process payload attributes");
+                                        continue
+                                    }
+                                }
+                                Err(err) => {
+                                    warn!(%err, "error reading payload attributes stream");
+                                    return Err(retry)
                                 }
                             }
-                            Err(err) => {
-                                warn!(%err, "error reading payload attributes stream");
-                                return Err(retry)
-                            }
                         }
-                    }
-                    Err(retry)
-                },
-            )
-            .await;
-            if result.is_err() {
-                error!("failed to read from event stream");
+                        Err(retry)
+                    },
+                )
+                .await;
+                if result.is_err() {
+                    error!(
+                        "failed to read from event stream with exponential backoff, restarting..."
+                    );
+                }
             }
         });
 


### PR DESCRIPTION
there seems to be some race condition with the `backoff` gadget that would cause the relay's payload attributes stream to terminate which would bring down the entire relay

without further investigation, this PR just loops that component of the relay, so even if there is failure, we simply try again