### PR TITLE
restore deadline priority for payload jobs

### DIFF
--- a/mev-build-rs/src/bidder/service.rs
+++ b/mev-build-rs/src/bidder/service.rs
@@ -5,7 +5,7 @@ use crate::{
 use reth::{primitives::U256, tasks::TaskExecutor};
 use std::sync::Arc;
 use tokio::sync::{mpsc::Receiver, oneshot};
-use tracing::warn;
+use tracing::trace;
 
 pub type RevenueUpdate = (U256, oneshot::Sender<Option<U256>>);
 
@@ -33,7 +33,8 @@ impl Service {
             while let Some((current_revenue, dispatch)) = revenue_updates.recv().await {
                 let value = strategy.run(&auction, current_revenue).await;
                 if dispatch.send(value).is_err() {
-                    warn!("could not send bid value to builder");
+                    trace!("channel closed; could not send bid value to builder");
+                    break
                 }
             }
         });

--- a/mev-build-rs/src/payload/job.rs
+++ b/mev-build-rs/src/payload/job.rs
@@ -139,18 +139,19 @@ where
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
 
+        // check if the deadline is reached
+        if this.deadline.as_mut().poll(cx).is_ready() {
+            trace!(target: "payload_builder", "payload building deadline reached");
+            return Poll::Ready(Ok(()))
+        }
+
         // poll for pending bids
-        // NOTE: this should happen before anything else to ensure synchronization
-        // invariants the bidding task relies on
-        let mut pending_bid = false;
         if let Some(mut fut) = this.pending_bid_update.take() {
-            pending_bid = true;
             match fut.poll_unpin(cx) {
                 Poll::Pending => {
                     this.pending_bid_update = Some(fut);
                 }
                 Poll::Ready(Ok(maybe_dispatch)) => {
-                    pending_bid = false;
                     if let Some((payload, value_to_bid)) = maybe_dispatch {
                         // TODO: handle the pending block, esp if this is the last bid
                         if let Some(proposal) = this.config.attributes.proposal.as_ref() {
@@ -179,18 +180,6 @@ where
                 }
                 // bidder has terminated, so we terminate this job
                 Poll::Ready(Err(_)) => return Poll::Ready(Ok(())),
-            }
-        }
-
-        // check if the deadline is reached
-        if this.deadline.as_mut().poll(cx).is_ready() {
-            trace!(target: "payload_builder", "payload building deadline reached");
-            if pending_bid {
-                // if we have reached the deadline, but still have a pending bid outstanding,
-                // return `Pending` to keep the job alive until we can settle the final bid update.
-                return Poll::Pending
-            } else {
-                return Poll::Ready(Ok(()))
             }
         }
 


### PR DESCRIPTION
the current implementation kept payload jobs alive much longer than necessary and lead to many stale blocks being submitted. this highlighted some inefficiencies in `mev-relay-rs` and to facilitate testing, I'll rollback this change around sub-future priority.

I plan to implement auction cancellation more cleanly with canonical head updates from reth, which would solve this cleanly. And the relay implementation should be further optimized as well. But this is a good immediate fix for the time being.