### PR TITLE
disable reth native operations via `RUSTFLAGS`

### DIFF
--- a/nix/mev-rs.nix
+++ b/nix/mev-rs.nix
@@ -6,7 +6,7 @@ let
     pname = "mev-rs";
     src = crane.cleanCargoSource (crane.path ../.);
     CARGO_PROFILE = "maxperf";
-    RUSTFLAGS = "-C target-cpu=native";
+    # RUSTFLAGS = "-C target-cpu=native";
     cargoExtraArgs = "--locked ${feature-set}";
     buildInputs = lib.optionals pkgs.stdenv.isLinux [
       openssl


### PR DESCRIPTION
these flags broke a remote build process, lets disable for now until we can debug further