### PR TITLE
boost: increase get payload timeout to 4s

### DIFF
--- a/mev-boost-rs/src/relay_mux.rs
+++ b/mev-boost-rs/src/relay_mux.rs
@@ -27,7 +27,7 @@ const VALIDATOR_REGISTRATION_TIME_OUT_SECS: u64 = 4;
 // Give relays this amount of time in seconds to return bids.
 const FETCH_BEST_BID_TIME_OUT_SECS: u64 = 1;
 // Give relays this amount of time in seconds to respond with a payload.
-const FETCH_PAYLOAD_TIME_OUT_SECS: u64 = 1;
+const FETCH_PAYLOAD_TIME_OUT_SECS: u64 = 4;
 
 #[derive(Debug)]
 struct AuctionContext {


### PR DESCRIPTION
1s is too aggressive, and at this point in the exchange we should give relays plenty of time